### PR TITLE
Add suport for `docker-compose`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Install and run Docker
 
 .. note::
 
-    On Ubuntu 12.04 state will also update kernel if needeed 
+    On Ubuntu 12.04 state will also update kernel if needeed
     (as mentioned in `docker installation docs <https://docs.docker.com/installation/ubuntulinux/>`_).
     You should manually reboot minions for kernel update to take affect.
 
@@ -32,3 +32,10 @@ Install and run Docker
 Run a Docker container to start the registry service using AWS S3 to store the images.
 
 It requires the docker state and the `python-formula <https://github.com/TeamLovely/python-formula>`_.
+
+``docker.compose``
+------------------
+
+Add support for using `Docker Compose <https://docs.docker.com/compose/>`_
+(previously ``fig``) to define groups of containers and their relationships
+with one another.

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,0 +1,9 @@
+{% from "docker/map.jinja" import compose with context %}
+
+compose-pip-dependencies:
+  pkg.installed:
+    - name: python-pip
+  pip.installed:
+    - name: docker-compose == {{ compose.version }}
+    - require:
+      - pkg: python-pip

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -34,3 +34,9 @@
 },
 grain='lsb_distrib_codename',
 merge=salt['pillar.get']('registry:lookup')) %}
+
+{% set compose = salt['grains.filter_by']({
+    'default': {
+        'version': '1.1.0'
+    },
+}, merge=salt['pillar.get']('registry:lookup')) %}


### PR DESCRIPTION
At this time, the [Docker Compose](https://docs.docker.com/compose/) interface is a pretty stable and cross platform option for running groups of related containers. In it's simplest form, defining and running a data only volume container linked to a related service container is really useful. I envision this as a building block for migrating the registry component of this formula away from an upstart specific service to a registry service container with a default option of using a local data volume only container for storage.