### PR TITLE
Update old syntax in pkgrepo

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -35,8 +35,9 @@ docker-dependencies:
 
 docker-repo:
     pkgrepo.managed:
-      - repo: 'deb http://get.docker.io/ubuntu docker main'
-      - file: '/etc/apt/sources.list.d/docker.list'
+      - humanname: Docker repo
+      - name: deb http://get.docker.io/ubuntu docker main
+      - file: /etc/apt/sources.list.d/docker.list
       - keyid: d8576a8ba88d21e9
       - keyserver: keyserver.ubuntu.com
       - require_in:


### PR DESCRIPTION
The repo declaration seems to have gone out of favor.  

- Name seems to be the preferred way to declare a state value.
- Unquoted string as the value
- Add a human name in addition to changing it

For the record, the source code for salt states seems to indicate that both name and repo work, but repo is no longer mentioned at all in the docs. I think this was a change for overall consistency within salt.