### PR TITLE
Refresh package list and ensure pull from docker repo

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -47,6 +47,8 @@ docker-repo:
 
 lxc-docker:
   pkg.latest:
+    - fromrepo: docker
+    - refresh: True
     - require:
       - pkg: docker-dependencies
 


### PR DESCRIPTION
I just ran into an issue where this formula was failing

```
WARNING: The following packages cannot be authenticated!
  lxc-docker-1.6.0 lxc-docker
E: There are problems and -y was used without --force-yes
```

This update resolves this failure