### PR TITLE
Allow to control version of docker pkg from pillars

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,4 +1,5 @@
 {% from "docker/map.jinja" import kernel with context %}
+{% from "docker/map.jinja" import pkg with context %}
 
 docker-python-apt:
   pkg.installed:
@@ -46,9 +47,12 @@ docker-repo:
         - pkg: docker-python-apt
 
 lxc-docker:
-  pkg.latest:
+  pkg.installed:
     - fromrepo: docker
+    {% if pkg %}
     - refresh: True
+    - version: {{ pkg.version }}
+    {% endif -%}
     - require:
       - pkg: docker-dependencies
 

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -40,3 +40,6 @@ merge=salt['pillar.get']('registry:lookup')) %}
         'version': '1.1.0'
     },
 }, merge=salt['pillar.get']('registry:lookup')) %}
+
+{% set pkg = salt['grains.filter_by']({
+}, merge=salt['pillar.get']('docker-pkg:lookup')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -5,3 +5,6 @@ registry:
       aws_bucket: 'my-registry'
       aws_key: 'ABCDEFGHIJK123456789'
       aws_secret: 'AbcD+efG-HIjK1+++23456+789'
+docker-pkg:
+  lookup:
+    version: 1.6.2


### PR DESCRIPTION
The main change is that I'm switching from `pkg.latest` to `pkg.installed` to be more idempotent and prevent wild updates of docker daemon.
Also we can control the version explicitely by adding it in the pillars.