### PR TITLE
Former third party debian packages are renamed.

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -51,8 +51,8 @@ lxc-docker:
   pkg.installed:
     - fromrepo: docker
     {% if pkg %}
+    {% if pkg.version -%}- name: lxc-docker-{{ pkg.version }}{% endif %}
     - refresh: True
-    - version: {{ pkg.version }}
     {% endif -%}
     - require:
       - pkg: docker-dependencies


### PR DESCRIPTION
per comment
https://github.com/saltstack-formulas/docker-formula/commit/23ffb71c954a2e92805ff7fb45fd81787689053d#commitcomment-11246319

@cdarwin 
I tested with former version and no version defined. All is working fine.
