### PR TITLE
Refresh flag is mostly useful for pkg.latest

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -52,10 +52,10 @@ lxc-docker:
   {% if pkg and 'version' in pkg %}
   pkg.installed:
     - name: lxc-docker-{{ pkg.version }}
-    - refresh: {{ pkg.refresh_repo }}
   {% else %}
   pkg.latest:
   {% endif %}
+    - refresh: {{ pkg.refresh_repo }}
     - fromrepo: docker
     - require:
       - pkg: docker-dependencies

--- a/pillar.example
+++ b/pillar.example
@@ -8,4 +8,5 @@ registry:
 docker-pkg:
   lookup:
     version: 1.6.2
+    refresh_repo: false
     process_signature: /usr/bin/docker


### PR DESCRIPTION
Make it available for `pkg.installed` or `pkg.latest`