### PR TITLE
Update docker package name and repo location

### DIFF
--- a/docker/codenamemap.yaml
+++ b/docker/codenamemap.yaml
@@ -1,0 +1,28 @@
+# vim: sts=2 ts=2 sw=2 et ai
+
+wheezy:
+  kernel:
+    pkg:
+      name: linux-image-amd64
+      fromrepo: wheezy-backports
+    pkgrepo:
+      name: deb http://http.debian.net/debian wheezy-backports main
+      humanname: Wheezy Backports
+      dist: wheezy-backports
+
+jessie:
+  kernel:
+    pkg:
+      name: linux-image-amd64
+      fromrepo: jessie-backports
+    pkgrepo:
+      name: deb http://http.debian.net/debian jessie-backports main
+      humanname: Jessie Backports
+      dist: jessie-backports
+
+precise:
+  kernel:
+    pkg:
+      pkgs:
+        - linux-image-generic-lts-raring
+        - linux-headers-generic-lts-raring

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -1,0 +1,6 @@
+# vim: sts=2 ts=2 sw=2 et ai
+
+docker:
+  process_signature: '/usr/bin/docker'
+  refresh_repo: True
+  config: []

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,5 +1,5 @@
 {% from "docker/map.jinja" import kernel with context %}
-{% from "docker/map.jinja" import pkg with context %}
+{% from "docker/map.jinja" import docker with context %}
 
 docker-python-apt:
   pkg.installed:
@@ -49,13 +49,13 @@ docker-repo:
       - pkg: docker-python-apt
 
 lxc-docker:
-  {% if pkg and "version" in pkg %}
+  {% if "version" in docker %}
   pkg.installed:
-    - name: lxc-docker-{{ pkg.version }}
+    - name: lxc-docker-{{ docker.version }}
   {% else %}
   pkg.latest:
   {% endif %}
-    - refresh: {{ pkg.refresh_repo }}
+    - refresh: {{ docker.refresh_repo }}
     - fromrepo: docker
     - require:
       - pkg: docker-dependencies
@@ -74,20 +74,17 @@ docker-service:
     - enable: True
     - watch:
       - file: /etc/default/docker
-    {% if pkg and "process_signature" in pkg %}
-    - sig: {{ pkg.process_signature }}
+    {% if "process_signature" in docker %}
+    - sig: {{ docker.process_signature }}
     {% endif %}
 
-docker-py package dependency:
+docker-py requirements:
   pkg.installed:
     - name: python-pip
-
-docker-py:
   pip.installed:
-    {% if pkg and "pip_version" in pkg %}
-    - name: docker-py {{ pkg.pip_version }}
+    {% if "pip_version" in docker %}
+    - name: docker-py {{ docker.pip_version }}
     {% endif %}
     - require:
       - pkg: lxc-docker
-      - pkg: python-pip
     - reload_modules: True

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,14 +1,13 @@
-{% from "docker/map.jinja" import kernel with context %}
 {% from "docker/map.jinja" import docker with context %}
 
 docker-python-apt:
   pkg.installed:
     - name: python-apt
 
-{% if kernel.pkgrepo is defined %}
-{{ grains["lsb_distrib_codename"] }}-backports-repo:
+{% if "pkgrepo" in docker.kernel %}
+{{ grains["oscodename"] }}-backports-repo:
   pkgrepo.managed:
-    {% for key, value in kernel.pkgrepo.items() %}
+    {% for key, value in docker.kernel.pkgrepo.items() %}
     - {{ key }}: {{ value }}
     {% endfor %}
     - require:
@@ -16,10 +15,10 @@ docker-python-apt:
     - onlyif: dpkg --compare-versions {{ grains["kernelrelease"] }} lt 3.8
 {% endif %}
 
-{% if kernel.pkg is defined %}
+{% if "pkg"  in docker.kernel %}
 docker-dependencies-kernel:
   pkg.installed:
-    {% for key, value in kernel.pkg.items() %}
+    {% for key, value in docker.kernel.pkg.items() %}
     - {{ key }}: {{ value }}
     {% endfor %}
     - require_in:

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -16,37 +16,6 @@
     },
 }, merge=salt['pillar.get']('registry:lookup:amazon')) %}
 
-{% set kernel = salt['grains.filter_by'] ({
-    'wheezy': {
-        'pkg': {
-            'name': 'linux-image-amd64',
-            'fromrepo': 'wheezy-backports'
-        },
-        'pkgrepo': {
-            'name': 'deb http://http.debian.net/debian wheezy-backports main',
-            'humanname': 'Wheezy Backports',
-            'dist': 'wheezy-backports'
-        }
-    },
-    'jessie': {
-        'pkg': {
-            'name': 'linux-image-amd64',
-            'fromrepo': 'jessie-backports'
-        },
-        'pkgrepo': {
-            'name': 'deb http://http.debian.net/debian jessie-backports main',
-            'humanname': 'Jessie Backports',
-            'dist': 'jessie-backports'
-        }
-    },
-    'precise': {
-        'pkg': {
-            'pkgs': ['linux-image-generic-lts-raring', 'linux-headers-generic-lts-raring']
-        }
-    },
-},
-grain='lsb_distrib_codename',
-merge=salt['pillar.get']('registry:lookup')) %}
 
 {% set compose = salt['grains.filter_by']({
     'default': {
@@ -56,6 +25,12 @@ merge=salt['pillar.get']('registry:lookup')) %}
 
 # Begin migration to new style map.jinja
 {% import_yaml "docker/defaults.yaml" as defaults %}
+{% import_yaml "docker/codenamemap.yaml" as codemap %}
+
 {% set pkg = salt['pillar.get']('docker-pkg:lookup', default={}, merge=True) %}
 {% do defaults.docker.update(pkg) %}
+
+{% set oscode = salt['grains.filter_by'](codemap, grain='oscodename') or {} %}
+{% do defaults.docker.update(oscode) %}
+
 {% set docker = salt['pillar.get']('docker', default=defaults['docker'], merge=True) %}

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -54,10 +54,8 @@ merge=salt['pillar.get']('registry:lookup')) %}
     },
 }, merge=salt['pillar.get']('registry:lookup')) %}
 
-{% set pkg = salt['grains.filter_by']({
-    'default': {
-        'process_signature': '/usr/bin/docker',
-        'refresh_repo': True,
-        'config': []
-    },
-}, merge=salt['pillar.get']('docker-pkg:lookup'), base='default') %}
+# Begin migration to new style map.jinja
+{% import_yaml "docker/defaults.yaml" as defaults %}
+{% set pkg = salt['pillar.get']('docker-pkg:lookup', default={}, merge=True) %}
+{% do defaults.docker.update(pkg) %}
+{% set docker = salt['pillar.get']('docker', default=defaults['docker'], merge=True) %}


### PR DESCRIPTION
fixes #41 

I have tested this with existing pillar data setting an older docker package version and docker-py pip version strings. I then removed this pillar data and ran another highstate which successfully upgrades the docker package to the latest version from the new repository. It also removes the old repo configuration.
