### PR TITLE
Move kernel states outside of init and only include when necessary

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,29 +1,7 @@
 {% from "docker/map.jinja" import docker with context %}
-
-docker-python-apt:
-  pkg.installed:
-    - name: python-apt
-
-{% if "pkgrepo" in docker.kernel %}
-{{ grains["oscodename"] }}-backports-repo:
-  pkgrepo.managed:
-    {% for key, value in docker.kernel.pkgrepo.items() %}
-    - {{ key }}: {{ value }}
-    {% endfor %}
-    - require:
-      - pkg: python-apt
-    - onlyif: dpkg --compare-versions {{ grains["kernelrelease"] }} lt 3.8
-{% endif %}
-
-{% if "pkg"  in docker.kernel %}
-docker-dependencies-kernel:
-  pkg.installed:
-    {% for key, value in docker.kernel.pkg.items() %}
-    - {{ key }}: {{ value }}
-    {% endfor %}
-    - require_in:
-      - pkg: docker package
-    - onlyif: dpkg --compare-versions {{ grains["kernelrelease"] }} lt 3.8
+{% if docker.kernel is defined %}
+include:
+  - .kernel
 {% endif %}
 
 docker-dependencies:

--- a/docker/kernel.sls
+++ b/docker/kernel.sls
@@ -1,0 +1,28 @@
+{% from "docker/map.jinja" import docker with context %}
+
+pkgrepo dependencies:
+  pkg.installed:
+    - name: python-apt
+
+{% if "pkgrepo" in docker.kernel %}
+{{ grains["oscodename"] }}-backports-repo:
+  pkgrepo.managed:
+    {% for key, value in docker.kernel.pkgrepo.items() %}
+    - {{ key }}: {{ value }}
+    {% endfor %}
+    - require:
+      - pkg: python-apt
+    - onlyif: dpkg --compare-versions {{ grains["kernelrelease"] }} lt 3.8
+{% endif %}
+
+{% if "pkg"  in docker.kernel %}
+docker-dependencies-kernel:
+  pkg.installed:
+    {% for key, value in docker.kernel.pkg.items() %}
+    - {{ key }}: {{ value }}
+    {% endfor %}
+    - require_in:
+      - pkg: docker package
+    - onlyif: dpkg --compare-versions {{ grains["kernelrelease"] }} lt 3.8
+{% endif %}
+


### PR DESCRIPTION
This addresses a regression added by d3574e4. We've talked about doing this in the past, anyway.