### PR TITLE
Fixes python-pip error

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -3,6 +3,4 @@
 compose-pip-dependencies:
   pip.installed:
     - name: docker-compose == {{ compose.version }}
-    - require:
-      - pkg: python-pip
     - reload_modules: true

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,8 +1,6 @@
 {% from "docker/map.jinja" import compose with context %}
 
 compose-pip-dependencies:
-  pkg.installed:
-    - name: python-pip
   pip.installed:
     - name: docker-compose == {{ compose.version }}
     - require:

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -79,8 +79,6 @@ docker-service:
     {% endif %}
 
 docker-py requirements:
-  pkg.installed:
-    - name: python-pip
   pip.installed:
     {%- if "pip_version" in docker %}
     - name: docker-py {{ docker.pip_version }}


### PR DESCRIPTION
With some python-pip packages we can encounter this issue
`ImportError: cannot import name 'IncompleteRead'`.

The solution here is to remove the install of pip. The idea is that formulas
should remain light and this dependency should be handled by the user of the
formula.