### PR TITLE
Installs current pip version

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,10 +1,15 @@
 {% from "docker/map.jinja" import compose with context %}
 
-compose-pip-dependencies:
+compose-pip:
   pkg.installed:
     - name: python-pip
   pip.installed:
+    - name: pip
+    - upgrade: True
+
+compose:
+  pip.installed:
     - name: docker-compose == {{ compose.version }}
     - require:
-      - pkg: python-pip
+      - pip: compose-pip
     - reload_modules: true

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -82,6 +82,11 @@ docker-py requirements:
   pkg.installed:
     - name: python-pip
   pip.installed:
+    - name: pip
+    - upgrade: True
+
+docker-py:
+  pip.installed:
     {%- if "pip_version" in docker %}
     - name: docker-py {{ docker.pip_version }}
     {%- else %}
@@ -89,4 +94,5 @@ docker-py requirements:
     {%- endif %}
     - require:
       - pkg: docker package
+      - pip: docker-py requirements
     - reload_modules: True


### PR DESCRIPTION
Docker-pip requires `requests==2.5.3` that can break the system version of pip. Here we first ensures pip is installed then we update it to its current pypi version to ensure it will continue to work with fresh
`requests` update.

cf: https://github.com/saltstack-formulas/docker-formula/issues/53