### PR TITLE
Works with jessie

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -13,6 +13,11 @@ docker package dependencies:
       - lxc
       - python-apt
 
+{%- if grains["oscodename"]|lower == 'jessie' %}
+docker package repository:
+  pkgrepo.managed:
+    - name: deb http://http.debian.net/debian jessie-backports main
+{%- else %}
 {%- if "version" in docker and docker.version < '1.7.1' %}
 docker package repository:
   pkgrepo.managed:
@@ -37,6 +42,7 @@ docker package repository:
     - keyserver: keyserver.ubuntu.com
     - file: /etc/apt/sources.list.d/docker.list
     - refresh_db: True
+{%- endif %}
     - require_in:
       - pkg: docker package
     - require:
@@ -45,7 +51,10 @@ docker package repository:
 docker package:
   {%- if "version" in docker %}
   pkg.installed:
-    {%- if  docker.version < '1.7.1' %}
+    {%- if grains["oscodename"]|lower == 'jessie' %}
+    - name: docker.io
+    - version: {{ docker.version }}
+    {%- elif  docker.version < '1.7.1' %}
     - name: lxc-docker-{{ docker.version }}
     {%- else %}
     - name: docker-engine
@@ -53,7 +62,11 @@ docker package:
     {%- endif %}
   {%- else %}
   pkg.latest:
+    {%- if grains["oscodename"]|lower == 'jessie' %}
+    - name: docker.io
+    {%- else %}
     - name: docker-engine
+    {%- endif %}
   {%- endif %}
     - refresh: {{ docker.refresh_repo }}
     - require:


### PR DESCRIPTION
Add ubuntu repo and use it jessie is not very classy. This PR aims to follow the debian jessie install from the docker: https://docs.docker.com/installation/debian/#debian-jessie-80-64-bit.