### PR TITLE
make it configurable whether to install docker_py or not

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -2,5 +2,6 @@
 
 docker:
   process_signature: '/usr/bin/docker'
+  install_docker_py: True
   refresh_repo: True
   config: []

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -91,6 +91,8 @@ docker-service:
     - sig: {{ docker.process_signature }}
     {% endif %}
 
+
+{% if docker.install_docker_py %}
 docker-py requirements:
   pkg.installed:
     - name: python-pip
@@ -109,3 +111,4 @@ docker-py:
       - pkg: docker package
       - pip: docker-py requirements
     - reload_modules: True
+{% endif %}

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -72,6 +72,7 @@ docker package:
     - require:
       - pkg: docker package dependencies
       - pkgrepo: docker package repository
+      - file: docker-config
 
 docker-config:
   file.managed:
@@ -87,6 +88,7 @@ docker-service:
     - enable: True
     - watch:
       - file: /etc/default/docker
+      - pkg: docker package
     {% if "process_signature" in docker %}
     - sig: {{ docker.process_signature }}
     {% endif %}


### PR DESCRIPTION
We had a bit of trouble installing this on very limited memory instances (new t2.nano type on EC2), so I thought making it optional without changing old behaviour with a sensible default makes sense here.