### PR TITLE
New docker package key id

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -37,7 +37,7 @@ docker package repository:
   pkgrepo.managed:
     - name: deb https://apt.dockerproject.org/repo {{ grains["os"]|lower }}-{{ grains["oscodename"] }} main
     - humanname: {{ grains["os"] }} {{ grains["oscodename"]|capitalize }} Docker Package Repository
-    - keyid: f76221572c52609d
+    - keyid: 58118E89F3A912897C070ADBF76221572C52609D
 {%- endif %}
     - keyserver: keyserver.ubuntu.com
     - file: /etc/apt/sources.list.d/docker.list


### PR DESCRIPTION
I was encountering errors with docker not installing until I updated the `keyid` to match what is in the docker install docs: [https://docs.docker.com/engine/installation/ubuntulinux/](https://docs.docker.com/engine/installation/ubuntulinux/)