### PR TITLE
Silence grep when fetching init system

### DIFF
--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -8,7 +8,7 @@ docker-image-{{ name }}:
       - service: docker-service
 
 {# TODO: SysV init script #}
-{%- set init_system = salt["cmd.run"]("ps -p1 | grep systemd && echo systemd || echo upstart") %}
+{%- set init_system = salt["cmd.run"]("ps -p1 | grep -q systemd && echo systemd || echo upstart") %}
 
 docker-container-startup-config-{{ name }}:
   file.managed:


### PR DESCRIPTION
Without the `-q`, grep's output was showing up, and causing the `if` statement on the service to not trigger either way. Should work properly based on return value now.