### PR TITLE
Allow to pin pip

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -113,8 +113,12 @@ docker-py requirements:
   pkg.installed:
     - name: python-pip
   pip.installed:
+    {%- if "pip" in docker and "version" in docker.pip %}
+    - name: pip {{ docker.pip.version }}
+    {%- else %}
     - name: pip
     - upgrade: True
+    {%- endif %}
 
 docker-py:
   pip.installed:

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,8 @@ docker-containers:
 
 docker-pkg:
   lookup:
+    pip:
+      version: '== 8.1.1'
     version: 1.6.2
     refresh_repo: false
     process_signature: /usr/bin/docker


### PR DESCRIPTION
Because predictability matters.

Sorry for the pillar name `pip_pip_version`. I'm open for suggestion.