### PR TITLE
Update key server for apt install

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -53,7 +53,7 @@ docker package repository:
     - humanname: {{ grains["os"] }} {{ grains["oscodename"]|capitalize }} Docker Package Repository
     - keyid: 58118E89F3A912897C070ADBF76221572C52609D
 {%- endif %}
-    - keyserver: keyserver.ubuntu.com
+    - keyserver: hkp://p80.pool.sks-keyservers.net:80
     - file: /etc/apt/sources.list.d/docker.list
     - refresh_db: True
 {%- endif %}


### PR DESCRIPTION
Current key server is giving error.  Updating key server per
instruction on Docker's blog:
https://blog.docker.com/2015/07/new-apt-and-yum-repos/