### PR TITLE
Support docker defaults file on systemd nodes

### DIFF
--- a/docker/files/systemd.drop-in
+++ b/docker/files/systemd.drop-in
@@ -1,0 +1,4 @@
+[Service]
+EnvironmentFile=-/etc/default/docker
+ExecStart=
+ExecStart=/usr/bin/docker daemon $DOCKER_OPTS -H fd://

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -96,6 +96,22 @@ docker-config:
     - mode: 644
     - user: root
 
+{% if salt['grains.has_value']('systemd') %}
+docker-unit-drop-in:
+  file.managed:
+    - name: /etc/systemd/system/docker.service.d/docker-defaults.conf
+    - source: salt://docker/files/systemd.drop-in
+    - makedirs: True
+    - require:
+      - file: docker-config
+
+reload-systemd:
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: docker-unit-drop-in
+{% endif %}
+
 docker-service:
   service.running:
     - name: docker


### PR DESCRIPTION
Test for systemd using the systemd grain.  If systemd exists, then add
the drop-in unit file to override docker startup using the environment
sourced from /etc/default/docker.

Fixes #74 