### PR TITLE
reload modules after docker-py installation

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -142,4 +142,5 @@ docker-py:
     {%- else %}
     - name: docker-py
     {%- endif %}
+    - reload_modules: true
 {% endif %}


### PR DESCRIPTION
Mostly useful when we upgrade docker-py. So dockerng can picks up new version immediately.