### PR TITLE
Allow image name without version for docker.pulled.

### DIFF
--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -4,9 +4,13 @@
   {%- set required_containers = [] %}
 {{id}} image:
   docker.pulled:
-  {%- set image = container.image.split(':',1) %}
+  {%- if ':' in container.image %}
+    {%- set image = container.image.split(':',1) %}
     - name: {{image[0]}}
     - tag: {{image[1]}}
+    {%- else %}
+    - name: {{container.image}}
+    {%- endif %}
 
 {{id}} container:
   {%- if 'dvc' in container and container.dvc %}

--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -8,9 +8,9 @@
     {%- set image = container.image.split(':',1) %}
     - name: {{image[0]}}
     - tag: {{image[1]}}
-    {%- else %}
+  {%- else %}
     - name: {{container.image}}
-    {%- endif %}
+  {%- endif %}
 
 {{id}} container:
   {%- if 'dvc' in container and container.dvc %}


### PR DESCRIPTION
As docker-compose.yml allows ``image`` attribute to be just the image name for ``latest``, ``docker.compose-ng`` should do the same.

So instead of allowing only:
``
image: tvial/docker-mailserver:latest
``

We should also allow:
``
image: tvial/docker-mailserver
``
