### PR TITLE
docker package: use "hold: True" if version is specified

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -73,6 +73,7 @@ docker package:
     - name: docker-engine
     - version: {{ docker.version }}
     {%- endif %}
+    - hold: True
   {%- else %}
   pkg.latest:
     {%- if grains["oscodename"]|lower == 'jessie' and "version" not in docker %}


### PR DESCRIPTION
This will prevent upgrades of the package when using `apt-get upgrade` etc.

This is currently supported only by APT and YUM.

Ref: https://docs.saltstack.com/en/latest/ref/states/all/salt.states.pkg.html#salt.states.pkg.installed