### PR TITLE
systemd should not automatically put containers in the backgroud

### DIFF
--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -19,7 +19,7 @@ After=docker.service
 
 [Service]
 Restart=always
-ExecStart=/usr/bin/docker run -d {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}
+ExecStart=/usr/bin/docker run {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}
 ExecStop=/usr/bin/docker stop {{ name }}
 ExecStopPost=/usr/bin/docker rm -f {{ name }}
 


### PR DESCRIPTION
This PR prevents a container to be automatically daemonized within systemd.

Basically, systemd takes care of daemonization, and it specifically tell us that to [avoid daemonizing the services ourselves](https://www.freedesktop.org/software/systemd/man/daemon.html)

The daemonization that happens prior to this PR, prevents a large number (all?) of docker images to be started because when docker daemonizes a container (-d option), the /usr/bin/docker command exits, and systemd tries to restart it a few times until it reaches the limit of failures and systemd stops the service.

At this point I'm uncertain how, or if, the current systemd support has been working at all for anybody.


