### PR TITLE
fix and test support for Debian Jessie

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: debian-jessie
+    driver_config:
+      run_command: /sbin/init
 
 suites:
   - name: default
@@ -21,4 +24,4 @@ suites:
 verifier:
   name: shell
   remote_exec: false
-  command: testinfra -vvv --connection=docker --hosts=kitchen@$KITCHEN_CONTAINER_ID --junit-xml junit-$KITCHEN_INSTANCE.xml test/integration/$KITCHEN_SUITE
+  command: testinfra -vvv --connection=docker --hosts=root@$KITCHEN_CONTAINER_ID --junit-xml junit-$KITCHEN_INSTANCE.xml test/integration/$KITCHEN_SUITE

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,16 @@ platforms:
 
 suites:
   - name: default
+  - name: version-1.12.2
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - docker
+        docker.sls:
+          docker:
+            version: '1.12.2*'
 
 verifier:
   name: shell

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: salt_solo
+  log_level: debug
   require_chef: false
   formula: docker
   state_top:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: salt_solo
+  require_chef: false
   formula: docker
   state_top:
     base:
@@ -22,6 +23,7 @@ suites:
   - name: default
   - name: version-1.12.2
     provisioner:
+      log_level: debug
       pillars:
         top.sls:
           base:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,7 +23,6 @@ suites:
   - name: default
   - name: version-1.12.2
     provisioner:
-      log_level: debug
       pillars:
         top.sls:
           base:

--- a/docker/files/config
+++ b/docker/files/config
@@ -1,9 +1,17 @@
 {% from "docker/map.jinja" import docker with context %}
 
+
 # Docker Upstart and SysVinit configuration file
 
+#
+# THIS FILE DOES NOT APPLY TO SYSTEMD
+#
+#   Please see the documentation for "systemd drop-ins":
+#   https://docs.docker.com/engine/articles/systemd/
+#
+
 # Customize location of Docker binary (especially for development testing).
-#DOCKER="/usr/local/bin/docker"
+#DOCKERD="/usr/local/bin/dockerd"
 
 # Use DOCKER_OPTS to modify the daemon startup options.
 #DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"

--- a/docker/files/systemd.drop-in
+++ b/docker/files/systemd.drop-in
@@ -1,4 +1,0 @@
-[Service]
-EnvironmentFile=-/etc/default/docker
-ExecStart=
-ExecStart=/usr/bin/docker daemon $DOCKER_OPTS -H fd://

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -96,22 +96,6 @@ docker-config:
     - mode: 644
     - user: root
 
-{% if salt['grains.has_value']('systemd') %}
-docker-unit-drop-in:
-  file.managed:
-    - name: /etc/systemd/system/docker.service.d/docker-defaults.conf
-    - source: salt://docker/files/systemd.drop-in
-    - makedirs: True
-    - require:
-      - file: docker-config
-
-reload-systemd:
-  module.wait:
-    - name: service.systemctl_reload
-    - watch:
-      - file: docker-unit-drop-in
-{% endif %}
-
 docker-service:
   service.running:
     - name: docker

--- a/pillar.example
+++ b/pillar.example
@@ -26,7 +26,7 @@ docker-pkg:
     # pip version is needed to maintain backwards compatibility with the above docker version
     pip_version: '<= 1.2.3'
     # config is only for sysvinit and upstart
-    # use systemd drop-ins in your own states if you need to customize arugments to docker
+    # use systemd drop-ins in your own states if you need to customize arguments to docker
     config: 
       - DOCKER_OPTS="-s btrfs --dns 192.168.0.2"
       - export http_proxy="http://192.168.0.4:3128/"

--- a/pillar.example
+++ b/pillar.example
@@ -25,7 +25,9 @@ docker-pkg:
     process_signature: /usr/bin/docker
     # pip version is needed to maintain backwards compatibility with the above docker version
     pip_version: '<= 1.2.3'
-    config:
+    # config is only for sysvinit and upstart
+    # use systemd drop-ins in your own states if you need to customize arugments to docker
+    config: 
       - DOCKER_OPTS="-s btrfs --dns 192.168.0.2"
       - export http_proxy="http://192.168.0.4:3128/"
 

--- a/test/integration/version-1.12.2/testinfra/test_docker.py
+++ b/test/integration/version-1.12.2/testinfra/test_docker.py
@@ -1,0 +1,12 @@
+import testinfra
+
+
+def test_package_is_installed(Package):
+    docker = Package('docker-engine')
+    assert docker.is_installed
+    assert docker.version.startswith('1.12.2')
+
+def test_service_is_running_and_enabled(Service):
+    docker = Service('docker')
+    assert docker.is_running
+    assert docker.is_enabled


### PR DESCRIPTION
This removes the systemd drop in that breaks support on Debian Jessie.

Formula users can create drop ins in their own states to override directives in the systemd service unit file that ships with packages.