### PR TITLE
Add container start/stop flexibility

### DIFF
--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -7,7 +7,6 @@ After=docker.service
 {%- set runoptions = container.get("runoptions", []) %}
 {%- set stopoptions = container.get("stopoptions", []) %}
 {%- set remove_on_stop = container.get("remove_on_stop", False) %}
-{%- set pull_image_on_start = container.get("pull_image_on_start", True)}
 {%- set cmd = container.get("cmd") or "" %}
 {%- set pull_before_start = container.get("pull_before_start") or False %}
 {%- if runoptions == "None" %}
@@ -21,7 +20,7 @@ After=docker.service
 
 [Service]
 Restart=always
-{%- if pull_before_start or pull_image_on_start %}
+{%- if pull_before_start %}
 ExecStartPre=/usr/bin/docker pull {{ container.image }}
 {%- endif %}
 ExecStart=/usr/bin/docker run {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}

--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -4,8 +4,10 @@ Requires=docker.service
 After=docker.service
 
 {#- Ugly, but covers the cases where variable evaluates to false, is empty, or non-existent #}
-{%- set runoptions = container.get("runoptions") or [] %}
-{%- set stopoptions = container.get("stopoptions") or [] %}
+{%- set runoptions = container.get("runoptions", []) %}
+{%- set stopoptions = container.get("stopoptions", []) %}
+{%- set remove_on_stop = container.get("remove_on_stop", False) %}
+{%- set pull_image_on_start = container.get("pull_image_on_start", True)}
 {%- set cmd = container.get("cmd") or "" %}
 
 {%- if runoptions == "None" %}
@@ -19,9 +21,14 @@ After=docker.service
 
 [Service]
 Restart=always
+{%- if pull_image_on_start %}
+ExecStartPre=/usr/bin/docker pull {{ name }}
+{%- endif %}
 ExecStart=/usr/bin/docker run {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}
-ExecStop=/usr/bin/docker stop {{ name }}
+ExecStop=/usr/bin/docker stop {% for option in stopoptions %}{{ option }} {% endfor %} {{ name }}
+{%- if remove_on_stop %}
 ExecStopPost=/usr/bin/docker rm -f {{ name }}
+{%- endif %}
 
 [Install]
 WantedBy=local.target

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -17,7 +17,7 @@ respawn
 {%- set cmd = "" %}
 {%- endif %}
 
-{%- if pull_before_start%}
+{%- if pull_before_start %}
 pre-start script
   /usr/bin/docker pull {{ container.image }}
 end script

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -7,7 +7,6 @@ respawn
 {%- set runoptions = container.get("runoptions", []) %}
 {%- set stopoptions = container.get("stopoptions", []) %}
 {%- set remove_on_stop = container.get("remove_on_stop", False) %}
-{%- set pull_image_on_start = container.get("pull_image_on_start", True)}
 {%- set cmd = container.get("cmd", "") %}
 {%- set pull_before_start = container.get("pull_before_start") or False %}
 {%- if runoptions == "None" %}
@@ -18,7 +17,7 @@ respawn
 {%- set cmd = "" %}
 {%- endif %}
 
-{%- if pull_image_on_start or pull_before_start%}
+{%- if pull_before_start%}
 pre-start script
   /usr/bin/docker pull {{ container.image }}
 end script

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -6,6 +6,8 @@ respawn
 {#- Ugly, but covers the cases where variable evaluates to false, is empty, or non-existent #}
 {%- set runoptions = container.get("runoptions", []) %}
 {%- set stopoptions = container.get("stopoptions", []) %}
+{%- set remove_on_stop = container.get("remove_on_stop", False) %}
+{%- set pull_image_on_start = container.get("pull_image_on_start", True)}
 {%- set cmd = container.get("cmd", "") %}
 
 {%- if runoptions == "None" %}
@@ -14,6 +16,12 @@ respawn
 
 {%- if cmd == "None" %}
 {%- set cmd = "" %}
+{%- endif %}
+
+{%- if pull_image_on_start %}
+pre-start script
+  /usr/bin/docker pull {{ name }}
+end script
 {%- endif %}
 
 script
@@ -31,5 +39,7 @@ pre-stop script
     {{ option }} \
   {%- endfor %}
     {{ name }}
-  /usr/bin/docker rm {{ name }}
+  {%- if remove_on_stop %}
+  /usr/bin/docker rm -f {{ name }}
+  {%- endif %}
 end script

--- a/pillar.example
+++ b/pillar.example
@@ -19,7 +19,7 @@ docker-containers:
 
       # these are default values if not provided
       remove_on_stop: false
-      pull_image_on_start: true
+      pull_before_start: true
 
 docker-pkg:
   lookup:

--- a/pillar.example
+++ b/pillar.example
@@ -16,6 +16,10 @@ docker-containers:
         - "-p 5000:5000"
         - "--rm"
 
+      # these are default values if not provided
+      remove_on_stop: false
+      pull_image_on_start: true
+
 docker-pkg:
   lookup:
     pip:


### PR DESCRIPTION
Features
* Does not force container to be removed on stop unless desired in pillar data
* Allows images to be pulled (updated) before starting container

Bugfixes
* Stop options not used in systemd template
* `-f` option missing in `docker rm` command in upstart template

resolves #99 