### PR TITLE
Do not always upgrade pip

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -5,3 +5,5 @@ docker:
   install_docker_py: True
   refresh_repo: True
   config: []
+  pip:
+    upgrade: False

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -113,11 +113,13 @@ docker-py requirements:
   pkg.installed:
     - name: python-pip
   pip.installed:
-    {%- if "pip" in docker and "version" in docker.pip %}
+    {%- if "pip" in docker and "version" in docker.pip and "version" in docker.pip %}
     - name: pip {{ docker.pip.version }}
     {%- else %}
     - name: pip
+    {%- if "pip" in docker and "upgrade" in docker.pip and docker.pip.upgrade %}
     - upgrade: True
+    {%- endif %}
     {%- endif %}
 
 docker-py:


### PR DESCRIPTION
I saw that every run it was trying to update pip. That is not always what I want as it slows down the state and is not idempotent. I have set in pillar docker.pip.upgrade default to False and can be overridden by Pillar.