### PR TITLE
Make formula compatible with RedHat family

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -2,6 +2,7 @@
 
 docker:
   process_signature: '/usr/bin/docker'
+  python_pip_package: 'python-pip'
   install_docker_py: True
   refresh_repo: True
   config: []

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -123,7 +123,7 @@ docker-service:
 {% if docker.install_docker_py %}
 docker-py requirements:
   pkg.installed:
-    - name: python-pip
+    - name: {{ docker.python_pip_package }}
   pip.installed:
     {%- if "pip" in docker and "version" in docker.pip %}
     - name: pip {{ docker.pip.version }}

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -7,11 +7,14 @@ include:
 docker package dependencies:
   pkg.installed:
     - pkgs:
+      {%- if grains['os_family']|lower == 'debian' %}
       - apt-transport-https
+      - python-apt
+      {%- endif %}
       - iptables
       - ca-certificates
-      - python-apt
 
+{%- if grains['os_family']|lower == 'debian' %}
 {%- if grains["oscodename"]|lower == 'jessie' and "version" not in docker%}
 docker package repository:
   pkgrepo.managed:
@@ -55,6 +58,15 @@ docker package repository:
     - keyserver: hkp://p80.pool.sks-keyservers.net:80
     - file: /etc/apt/sources.list.d/docker.list
     - refresh_db: True
+{%- endif %}
+
+{%- else %}
+docker package repository:
+  pkgrepo.managed:
+    - name: docker
+    - baseurl: https://yum.dockerproject.org/repo/main/centos/$releasever/
+    - gpgcheck: 1
+    - gpgkey: https://yum.dockerproject.org/gpg
 {%- endif %}
     - require_in:
       - pkg: docker package


### PR DESCRIPTION
The module currently only works with Ubuntu (and familiy I guess). I've modified the module to work with CentOS/RedHat familiy. I've tested the install (the docker-state). Als I faced an issue whereby the python-pip module not always was named python-pip, and this can be overridden by Pillar docker.python_pip_package.

It can be needed for python-pip to install EPEL repository. This can be done by the [epel formula](https://github.com/saltstack-formulas/epel-formula), but I think this module should not depend on that.