### PR TITLE
Revert "test support for Ubuntu Xenial"

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,9 +16,6 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  - name: ubuntu-16.04
-    driver_config:
-      run_command: /sbin/init
   - name: debian-jessie
     driver_config:
       run_command: /sbin/init


### PR DESCRIPTION
Reverts saltstack-formulas/docker-formula#94

This made the test suite run too long. Reverting for now.