### PR TITLE
Updated references to python-pip to python2-pip

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -2,7 +2,7 @@
 
 compose-pip:
   pkg.installed:
-    - name: python-pip
+    - name: python2-pip
   pip.installed:
     - name: pip
     - upgrade: True

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -2,7 +2,7 @@
 
 docker:
   process_signature: '/usr/bin/docker'
-  python_pip_package: 'python-pip'
+  python_pip_package: 'python2-pip'
   install_docker_py: False
   refresh_repo: True
   config: []


### PR DESCRIPTION
`python-pip` no longer exists in EPEL and has been changed to `python2-pip`