### PR TITLE
Pull docker image on service restart

### DIFF
--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -7,7 +7,7 @@ After=docker.service
 {%- set runoptions = container.get("runoptions") or [] %}
 {%- set stopoptions = container.get("stopoptions") or [] %}
 {%- set cmd = container.get("cmd") or "" %}
-
+{%- set pull_before_start = container.get("pull_before_start") or False %}
 {%- if runoptions == "None" %}
 {%- set runoptions = [] %}
 {%- endif %}
@@ -19,6 +19,9 @@ After=docker.service
 
 [Service]
 Restart=always
+{%- if pull_before_start %}
+ExecStartPre=/usr/bin/docker pull {{ container.image }}
+{%- endif %}
 ExecStart=/usr/bin/docker run {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}
 ExecStop=/usr/bin/docker stop {{ name }}
 ExecStopPost=/usr/bin/docker rm -f {{ name }}

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -7,13 +7,19 @@ respawn
 {%- set runoptions = container.get("runoptions", []) %}
 {%- set stopoptions = container.get("stopoptions", []) %}
 {%- set cmd = container.get("cmd", "") %}
-
+{%- set pull_before_start = container.get("pull_before_start") or False %}
 {%- if runoptions == "None" %}
 {%- set runoptions = [] %}
 {%- endif %}
 
 {%- if cmd == "None" %}
 {%- set cmd = "" %}
+{%- endif %}
+
+{%- if pull_before_start %}
+pre-start script
+  /usr/bin/docker pull {{ container.image }}
+end script
 {%- endif %}
 
 script

--- a/pillar.example
+++ b/pillar.example
@@ -6,6 +6,7 @@ docker-containers:
     registry:
       image: "registry:2"
       cmd:
+      pull_before_start: True # Pull image on service restart (useful if you override the same tag. example: latest)
       runoptions:
         - "-e REGISTRY_LOG_LEVEL=warn"
         - "-e REGISTRY_STORAGE=s3"


### PR DESCRIPTION
**Before:**
If you have a docker tag image and you override it often you have to pull the image manually and then restart the service.
**After:**
Add pull_before_start option and docker will pull the image on restart