### PR TITLE
cmd is printed with brackets in systemd/upstart service definitions

### DIFF
--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -11,7 +11,8 @@ docker-image-{{ name }}:
       - service: docker-service
 
 {# TODO: SysV init script #}
-{%- set init_system = salt["cmd.run"]("ps -p1 | grep -q systemd && echo systemd || echo upstart") %}
+{# Use grains instead of command to get init system #}
+{%- set init_system = grains['init'] %}
 
 docker-container-startup-config-{{ name }}:
   file.managed:

--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -14,6 +14,8 @@ After=docker.service
 
 {%- if cmd == "None" %}
 {%- set cmd = "" %}
+{%- else %}
+{%- set cmd = cmd|join(' ') %}
 {%- endif %}
 
 

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -14,6 +14,8 @@ respawn
 
 {%- if cmd == "None" %}
 {%- set cmd = "" %}
+{%- else %}
+{%- set cmd = cmd|join(' ') %}
 {%- endif %}
 
 script


### PR DESCRIPTION
The _cmd_ pillar argument is printed as a list to the systemd/upstart service definitions. This upsets somme applications.

Example pillar:
```
docker-containers:
  lookup:
    prometheus-server:
      image: "prom/prometheus:v1.7.1"
      cmd:
        - '-config.file=/prom-data/prometheus.yml'
        - '-storage.local.path=/prom-data/data/'
      runoptions:
        - "-p 9090:9090"
        - '--net="host"'
        - '-v /mnt/prom-data:/prom-data'
```

Resulting systemd service file:
```
[...]
ExecStart=/usr/bin/docker run -p 9090:9090 --net="host" -v /mnt/prom-data:/prom-data  --name=prometheus-server prom/prometheus:v1.7.1 ['-config.file=/prom-data/prometheus.yml', '-storage.local.path=/prom-data/data/']
[...]
```

This should be:
```
ExecStart=/usr/bin/docker run -p 9090:9090 --net="host" -v /mnt/prom-data:/prom-data  --name=prometheus-server prom/prometheus:v1.7.1 -config.file=/prom-data/prometheus.yml -storage.local.path=/prom-data/data/
```

Note the missing brackets and quotes at the end of the command line.

This seems to be because of line 22 in `docker/files/systemd.conf` and 25 in `docker/files/upstard.conf`.
Those lines print the _cmd_ variable which is a list, whose representation is of the form `[ 'a', 'b', 'c']`.

This patch converts the list to a string by concatenating its contents and joining them with an empty space.

Alternatively, an _args_ argument could be introduced to separate the command from the arguments.