### PR TITLE
Change WantedBy target to multi-user

### DIFF
--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -24,4 +24,4 @@ ExecStop=/usr/bin/docker stop {{ name }}
 ExecStopPost=/usr/bin/docker rm -f {{ name }}
 
 [Install]
-WantedBy=local.target
+WantedBy=multi-user.target


### PR DESCRIPTION
local.target doesn't exist by default, so the Docker container doesn't
start automatically when enabled.