### PR TITLE
Do not duplicate messages to systemd-journald service

### DIFF
--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -22,6 +22,7 @@ Restart=always
 ExecStart=/usr/bin/docker run {% for option in runoptions %}{{ option }} {% endfor %} --name={{ name }} {{ container.image }} {{ cmd }}
 ExecStop=/usr/bin/docker stop {{ name }}
 ExecStopPost=/usr/bin/docker rm -f {{ name }}
+StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default container messages are duplicated to systemd-journald
because container runs as systemd service