### PR TITLE
Fix docker.compose.version pillar. Breaks compose-ng

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,4 +1,4 @@
-{% from "docker/map.jinja" import compose with context %}
+{% from "docker/map.jinja" import docker with context %}
 
 compose-pip:
   pkg.installed:
@@ -9,8 +9,8 @@ compose-pip:
 
 compose:
   pip.installed:
-    {%- if "version" in compose %}
-    - name: docker-compose == {{ compose.version }}
+    {%- if "version" in docker.compose_version %}
+    - name: docker-compose == {{ docker.compose_version }}
     {%- else %}
     - name: docker-compose
     {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -57,11 +57,10 @@ docker-pkg:
 
 # Docker compose supported attributes
 docker:
-  compose:
-    # the version of docker compose to install.
-    # if this is omitted, installs the latest version using PIP
-    version: 1.9.0
+  # version of docker-compose to install (defaults to latest)
+  compose_version: 1.9.0
 
+  compose:
     registry-data:
       dvc: True
       image: &registry_image 'library/registry:0.9.1'


### PR DESCRIPTION
This PR fixes issue caused by `docker.compose.version` pillar  (I closed #132 by mistake)

**Pillar**
```
docker:
  compose:
    version: '==1.9.0'
```

**Jinja2 error in `compose-ng` state**
```
ERROR   ] Rendering exception occurred: Jinja error: argument of type 'StrictUndefined' is not iterable
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 418, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 11, in top-level template code
TypeError: argument of type 'StrictUndefined' is not iterable
```