### PR TITLE
Support newer salt docker api in compose-ng

### DIFF
--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -1,9 +1,16 @@
+{%- from "docker/map.jinja" import docker with context %}
 {%- from "docker/map.jinja" import compose with context %}
 {%- for name, container in compose.items() %}
   {%- set id = container.container_name|d(name) %}
   {%- set required_containers = [] %}
+    {%- if grains['saltversioninfo'] >= [2017, 7, 0]  %}
+{{id}}:
+  docker_image.present:
+    - force: {{ docker.containers.force_present }}
+    {%- else %}
 {{id}} image:
   docker.pulled:
+    {%- endif %}
   {%- if ':' in container.image %}
     {%- set image = container.image.split(':',1) %}
     - name: {{image[0]}}
@@ -13,11 +20,17 @@
   {%- endif %}
 
 {{id}} container:
-  {%- if 'dvc' in container and container.dvc %}
+     {%- if grains['saltversioninfo'] >= [2017, 7, 0] %}
+  docker_container.running:
+    - skip_translate: {{ docker.containers.skip_translate }}
+    - force: {{ docker.containers.force_running }}
+     {%- else %}
+       {%- if 'dvc' in container and container.dvc %}
   docker.installed:
-  {%- else %}
+       {%- else %}
   docker.running:
-  {%- endif %}
+       {%- endif %}
+     {%- endif %}
     - name: {{id}}
     - image: {{container.image}}
   {%- if 'command' in container %}
@@ -76,10 +89,18 @@
     {%- endif %}
   {%- endif %}
     - require:
+         {%- if grains['saltversioninfo'] >= [2017, 7, 0] %}
+      - docker_image: {{id}}
+         {%- else %}
       - docker: {{id}} image
+         {%- endif %}
   {%- if required_containers is defined %}
     {%- for containerid in required_containers %}
+         {%- if grains['saltversioninfo'] >= [2017, 7, 0] %}
+      - docker_image: {{containerid}}
+         {%- else %}
       - docker: {{containerid}}
+         {%- endif %}
     {%- endfor %}
   {%- endif %}
 {% endfor %}

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -9,7 +9,7 @@ compose-pip:
 
 compose:
   pip.installed:
-    {%- if "version" in docker.compose_version %}
+    {%- if docker.compose_version %}
     - name: docker-compose == {{ docker.compose_version }}
     {%- else %}
     - name: docker-compose

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -7,3 +7,9 @@ docker:
   refresh_repo: True
   config: []
   use_upstream_repo: True
+  compose_version:
+
+  containers:
+    skip_translate: None
+    force_present: False
+    force_running: False


### PR DESCRIPTION
This PR does following-

- support new docker, dockerng, API introduced in Salt 2017,7.0
- adds support for two related container parameters (`force`, `skip_translate`) with defaults.

Complimented by #135 