### PR TITLE
Fix broken compose.sls introduced by #134

### DIFF
--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -1,4 +1,8 @@
 {%- from "docker/map.jinja" import compose with context %}
+
+include:
+  - docker.compose
+
 {%- for name, container in compose.items() %}
   {%- set id = container.container_name|d(name) %}
   {%- set required_containers = [] %}

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -9,7 +9,7 @@ compose-pip:
 
 compose:
   pip.installed:
-    {%- if "version" in docker.compose_version %}
+    {%- if docker.compose_version %}
     - name: docker-compose == {{ docker.compose_version }}
     {%- else %}
     - name: docker-compose

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -7,3 +7,4 @@ docker:
   refresh_repo: True
   config: []
   use_upstream_repo: True
+  compose_version:


### PR DESCRIPTION
Please merge this fix.  The README is misleading, 

```Installs Docker Compose (previously fig) to define groups of containers and their relationships with one another. Use docker.compose-ng to run docker-compose.```

leading me to believe only `compose-ng` is needed in topfile.  However, `compose` is also needed in topfile.  Its not included by `compose-ng`.
  
This PR fixes broken compose.sls caused by #134 

```
----------
          ID: compose
    Function: pip.installed
        Name: docker-compose
      Result: True
     Comment: All packages were successfully installed
     Started: 13:46:04.517517
    Duration: 8642.643 ms
     Changes:   
              ----------
              docker-compose==1.19.0:
                  Installed
```
