### PR TITLE
systemd: service file should not be executable

### DIFF
--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -23,7 +23,7 @@ docker-container-startup-config-{{ name }}:
     - name: /etc/init/docker-{{ name }}.conf
     - source: salt://docker/files/upstart.conf
 {%- endif %}
-    - mode: 700
+    - mode: 600
     - user: root
     - template: jinja
     - defaults:


### PR DESCRIPTION
systemd complained with:

> Configuration file /etc/systemd/system/docker-registry.service is marked executable. Please remove executable permission bits. Proceeding anyway.