### PR TITLE
No iptables, ca-certificates on MacOS

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -13,6 +13,7 @@ docker package dependencies:
       {%- endif %}
       - iptables
       - ca-certificates
+    - unless: test "`uname`" = "Darwin"
 
 {% set repo_state = 'absent' %}
 {% if docker.use_upstream_repo %}


### PR DESCRIPTION
On MacOS, prevent homebrew failure installing `ca-certificates` and `iptables`.