### PR TITLE
Install one pip binary only (not two)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ driver:
 
 provisioner:
   name: salt_solo
-  log_level: debug
+  log_level: warning
   require_chef: false
   formula: docker
   state_top:
@@ -15,14 +15,20 @@ provisioner:
         - docker
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+    driver_config:
+      provision_command:
+        - apt-get update
+      run_command: /lib/systemd/systemd
   - name: debian-jessie
     driver_config:
-      run_command: /sbin/init
+      provision_command:
+        - apt-get update
+      run_command: /lib/systemd/systemd
 
 suites:
   - name: default
-  - name: version-1.12.2
+  - name: version-1.13.1
     provisioner:
       pillars:
         top.sls:
@@ -31,7 +37,22 @@ suites:
               - docker
         docker.sls:
           docker:
-            version: '1.12.2*'
+            version: '1.13.1*'
+    excludes:
+      - debian-jessie
+      
+  - name: version-1.6.2
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - docker
+        docker.sls:
+          docker:
+            version: '1.6.2*'
+    excludes:
+      - ubuntu-16.04
 
 verifier:
   name: shell

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,13 +1,12 @@
 {% from "docker/map.jinja" import docker with context %}
 
-compose-pip:
+docker-compose-pip:
   pkg.installed:
     - name: python-pip
-  pip.installed:
-    - name: pip
-    - upgrade: True
+    - require_in:
+      - pkg: docker-compose
 
-compose:
+docker-compose:
   pip.installed:
     {%- if docker.compose_version %}
     - name: docker-compose == {{ docker.compose_version }}

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -27,13 +27,13 @@ docker package repository:
     - name: deb http://http.debian.net/debian jessie-backports main
 {%- else %}
   {%- if "version" in docker %}
-    {%- if (docker.version|string).startswith('1.7.') %}
-      {%- set use_old_repo = docker.version < '1.7.1' %}
+    {%- if (docker.version|string).startswith('1.5.') %}
+      {%- set use_old_repo = docker.version < '1.5.1' %}
     {%- else %}
       {%- set version_major = (docker.version|string).split('.')[0]|int %}
       {%- set version_minor = (docker.version|string).split('.')[1]|int %}
       {%- set old_repo_major = 1 %}
-      {%- set old_repo_minor = 7 %}
+      {%- set old_repo_minor = 5 %}
       {%- set use_old_repo = (version_major < old_repo_major or (version_major == old_repo_major and version_minor < old_repo_minor)) %}
     {%- endif %}
   {%- endif %}
@@ -140,15 +140,6 @@ docker-service:
 docker-py requirements:
   pkg.installed:
     - name: {{ docker.python_pip_package }}
-  pip.installed:
-    {%- if "pip" in docker and "version" in docker.pip and "version" in docker.pip %}
-    - name: pip {{ docker.pip.version }}
-    {%- else %}
-    - name: pip
-    {%- if "pip" in docker and "upgrade" in docker.pip and docker.pip.upgrade %}
-    - upgrade: True
-    {%- endif %}
-    {%- endif %}
 
 docker-py:
   pip.installed:

--- a/test/integration/version-1.13.1/testinfra/test_docker.py
+++ b/test/integration/version-1.13.1/testinfra/test_docker.py
@@ -1,10 +1,9 @@
 import testinfra
 
-
 def test_package_is_installed(Package):
     docker = Package('docker-engine')
     assert docker.is_installed
-    assert docker.version.startswith('1.12.2')
+    assert docker.version.startswith('1.13.1')
 
 def test_service_is_running_and_enabled(Service):
     docker = Service('docker')

--- a/test/integration/version-1.6.2/testinfra/test_docker.py
+++ b/test/integration/version-1.6.2/testinfra/test_docker.py
@@ -1,0 +1,11 @@
+import testinfra
+
+def test_package_is_installed(Package):
+    docker = Package('docker-engine')
+    assert docker.is_installed
+    assert docker.version.startswith('1.6.2')
+
+def test_service_is_running_and_enabled(Service):
+    docker = Service('docker')
+    assert docker.is_running
+    assert docker.is_enabled


### PR DESCRIPTION
The formula should install one **pip implementation** only (not two).  
Resolves #133, avoids #144 & #96