### PR TITLE
Trusty needs storage drivers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ driver:
 
 provisioner:
   name: salt_solo
-  log_level: debug
+  log_level: warning
   require_chef: false
   formula: docker
   state_top:
@@ -15,14 +15,23 @@ provisioner:
         - docker
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+    driver_config:
+      image: ubuntu:16.04
+      provision_command:
+        - apt-get update && apt-get install -y locales ifupdown
+        - locale-gen en_US.UTF-8
+        - update-locale LANG=en_US.UTF-8
+      run_command: /lib/systemd/systemd
   - name: debian-jessie
     driver_config:
+      provision_command:
+        - apt-get update
       run_command: /sbin/init
 
 suites:
   - name: default
-  - name: version-1.12.2
+  - name: version-1.13.1
     provisioner:
       pillars:
         top.sls:
@@ -31,7 +40,22 @@ suites:
               - docker
         docker.sls:
           docker:
-            version: '1.12.2*'
+            version: '1.13.1*'
+    excludes:
+      - debian-jessie
+      
+  - name: version-1.6.2
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - docker
+        docker.sls:
+          docker:
+            version: '1.6.2*'
+    excludes:
+      - ubuntu-16.04
 
 verifier:
   name: shell

--- a/docker/codenamemap.yaml
+++ b/docker/codenamemap.yaml
@@ -20,9 +20,15 @@ jessie:
       humanname: Jessie Backports
       dist: jessie-backports
 
+trusty:
+  kernel:
+    pkgs:
+      - linux-image-extra-virtual
+      - linux-image-extra-{{ grains.kernelrelease }}
+
 precise:
   kernel:
-    pkg:
-      pkgs:
-        - linux-image-generic-lts-raring
-        - linux-headers-generic-lts-raring
+    pkgs:
+      - linux-image-generic-lts-raring
+      - linux-headers-generic-lts-raring
+

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -17,3 +17,6 @@ docker:
     skip_translate: None
     force_present: False
     force_running: False
+
+  kernel:
+    pkgs: []

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -13,6 +13,11 @@ docker package dependencies:
       {%- endif %}
       - iptables
       - ca-certificates
+      {% if docker.kernel.pkgs is defined %}
+        {% for pkg in docker.kernel.pkgs %}
+        - {{ pkg }}
+        {% endfor %}
+      {% endif %}
     - unless: test "`uname`" = "Darwin"
 
 {% set repo_state = 'absent' %}
@@ -27,13 +32,13 @@ docker package repository:
     - name: deb http://http.debian.net/debian jessie-backports main
 {%- else %}
   {%- if "version" in docker %}
-    {%- if (docker.version|string).startswith('1.7.') %}
-      {%- set use_old_repo = docker.version < '1.7.1' %}
+    {%- if (docker.version|string).startswith('1.5.') %}
+      {%- set use_old_repo = docker.version < '1.5.1' %}
     {%- else %}
       {%- set version_major = (docker.version|string).split('.')[0]|int %}
       {%- set version_minor = (docker.version|string).split('.')[1]|int %}
       {%- set old_repo_major = 1 %}
-      {%- set old_repo_minor = 7 %}
+      {%- set old_repo_minor = 5 %}
       {%- set use_old_repo = (version_major < old_repo_major or (version_major == old_repo_major and version_minor < old_repo_minor)) %}
     {%- endif %}
   {%- endif %}
@@ -86,7 +91,7 @@ docker package:
     - name: docker.io
     - version: {{ docker.version }}
     {%- elif use_old_repo %}
-    - name: lxc-docker-{{ docker.version }}
+    - name: lxc-docker
     {%- else %}
     {%- if grains['os']|lower in ('amazon', 'fedora', 'suse',) %}
     - name: docker

--- a/test/integration/version-1.13.1/testinfra/test_docker.py
+++ b/test/integration/version-1.13.1/testinfra/test_docker.py
@@ -1,0 +1,11 @@
+import testinfra
+
+def test_package_is_installed(Package):
+    docker = Package('docker-engine')
+    assert docker.is_installed
+    assert docker.version.startswith('1.13.1')
+
+def test_service_is_running_and_enabled(Service):
+    docker = Service('docker')
+    assert docker.is_running
+    assert docker.is_enabled

--- a/test/integration/version-1.6.2/testinfra/test_docker.py
+++ b/test/integration/version-1.6.2/testinfra/test_docker.py
@@ -1,0 +1,11 @@
+import testinfra
+
+def test_package_is_installed(Package):
+    docker = Package('docker-engine')
+    assert docker.is_installed
+    assert docker.version.startswith('1.6.2')
+
+def test_service_is_running_and_enabled(Service):
+    docker = Service('docker')
+    assert docker.is_running
+    assert docker.is_enabled


### PR DESCRIPTION
- Resolves #103 on Trusty.
- Updated Kitchen Tests.

From: https://docs.docker.com/install/linux/docker-ce/ubuntu/#supported-storage-drivers
> Unless you have a strong reason not to, install the linux-image-extra-* packages, which allow Docker to use the aufs storage drivers.
> 
> $ sudo apt-get update
> 
> $ sudo apt-get install \
>     linux-image-extra-$(uname -r) \
>     linux-image-extra-virtual