### PR TITLE
Fixed undefined use_old_repo variable error

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -89,7 +89,7 @@ docker package:
     {%- if grains["oscodename"]|lower == 'jessie' %}
     - name: docker.io
     - fromrepo: {{ docker.kernel.pkg.fromrepo }}
-    {%- elif use_old_repo %}
+    {%- elif use_old_repo is defined %}
     - name: lxc-docker
     {%- else %}
       {%- if grains['os']|lower in ('amazon', 'fedora', 'suse',) %}


### PR DESCRIPTION
Fixed this error
```
You asked for latest and you have 2018.3.2 installed, sweet!
       Transferring files to <default-ubuntu-1604>
       [ERROR   ] Rendering exception occurred
       Traceback (most recent call last):
         File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 170, in render_tmpl
           output = render_str(tmplstr, context, tmplpath)
         File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 399, in render_jinja_tmpl
           buf=tmplstr)
       SaltRenderError: Jinja variable 'use_old_repo' is undefined
       [CRITICAL] Rendering SLS 'base:docker' failed: Jinja variable 'use_old_repo' is undefined
       local:
           Data failed to compile:
       ----------
           Rendering SLS 'base:docker' failed: Jinja variable 'use_old_repo' is undefined
```
