### PR TITLE
add pip packagename for freebsd os

### DIFF
--- a/docker/osmap.yaml
+++ b/docker/osmap.yaml
@@ -3,4 +3,8 @@ CentOS:
   pip:
     pkgname: python2-pip
 
+FreeBSD:
+  pip:
+    pkgname: devel/py-pip
+
 # vim: ft=sls


### PR DESCRIPTION
```
# [[ -d /usr/ports/devel/py-pip ]] && echo "package name is 'devel/py-pip' on FreeBSD ports"
package name is 'devel/py-pip' on FreeBSD ports

# pip --version
pip 9.0.3 from /usr/local/lib/python2.7/site-packages (python 2.7)
```