### PR TITLE
Fix require_in and include docker state

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,10 +1,13 @@
 {% from "docker/map.jinja" import docker with context %}
 
+include:
+  - docker
+
 docker-compose-pip:
   pkg.installed:
     - name: {{ docker.pip.pkgname }}
     - require_in:
-      - pkg: docker-compose
+      - pip: docker-compose
 
 docker-compose:
   pip.installed:


### PR DESCRIPTION
Fixes
1. Include docker (`compose` depends on `init` state)
2. Fix `require_in` condition - value `pip` not `pkg`
