### PR TITLE
Add  docker.remove state

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@ provisioner:
   state_top:
     base:
       '*':
+        - docker.remove
         - docker
   pillars:
     top.sls:
@@ -60,6 +61,16 @@ suites:
             use_old_repo: true
     excludes:
       - ubuntu-18.04
+  - name: version-18
+    provisioner:
+      pillars:
+        docker.sls:
+          docker:
+            version: '18.*'
+            use_old_repo: true
+    excludes:
+      - debian-stretch
+      - debian-jessie
 
 verifier:
   name: shell

--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,11 @@ In this case, extra *docker run* options can be provided in your *"registry:look
 
 By default, the storage backend used by the registry is "filesystem". Use environment variables to override that, for example to use S3 as backend storage.
 
+``docker.remove``
+----------------
+
+Stop Docker daemon. Remove older docker packages (usually called 'docker' and 'docker-engine').
+
 Development
 ===========
 

--- a/docker/remove.sls
+++ b/docker/remove.sls
@@ -1,0 +1,26 @@
+{% from "docker/map.jinja" import docker with context %}
+
+docker packages cleaned service-dead:
+  service.dead:
+    - name: docker
+    {% if "process_signature" in docker %}
+    - sig: {{ docker.process_signature }}
+    {% endif %}
+    - require_in:
+      - pkg: docker packages cleaned
+
+docker packages cleaned:
+  pkg.removed:
+    - pkgs:
+      - {{ docker.pkg.old_name if docker.use_old_repo else docker.pkg.name }}
+      - docker
+      - docker.io
+      - docker-client
+      - docker-client-latest
+      - docker-common
+      - docker-latest
+      - docker-latest-logrotate
+      - docker-logrotate
+      - docker-selinux
+      - docker-engine-selinux
+      - docker-engine

--- a/test/integration/version-18/testinfra/test_docker.py
+++ b/test/integration/version-18/testinfra/test_docker.py
@@ -1,8 +1,7 @@
 import testinfra
 
-
 def test_package_is_installed(Package):
-    docker = Package('docker-ce')
+    docker = Package('docker-engine')
     assert docker.is_installed
     assert docker.version.startswith('18.')
 


### PR DESCRIPTION
[Docker install documentation](https://docs.docker.com/install/linux/docker-ce/centos/#prerequisites) says Uninstall old versions first ... 
> Older versions of Docker were called docker or docker-engine. If these are installed, uninstall them, along with associated dependencies.

This PR adds `docker.remove` state to automate manual steps.
```
base:
  "*":
    - docker.remove
    - docker
```