### PR TITLE
Fix python-pip jinja variable name

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -62,7 +62,7 @@ docker-service:
 {% if docker.install_docker_py %}
 docker-py requirements:
   pkg.installed:
-    - name: {{ docker.python_pip_package }}
+    - name: {{ docker.pip.pkgname }}
 
 docker-py:
   pip.installed:


### PR DESCRIPTION
This PR corrects a variable name ... probably `docker.pip.pkgname` is intended.

```
$ grep -r python_pip_package .
./docker/init.sls:    - name: {{ docker.python_pip_package }}
```