### PR TITLE
Use os_family to support Raspbian

### DIFF
--- a/docker/repo.sls
+++ b/docker/repo.sls
@@ -7,7 +7,7 @@
 
 {% set humanname_old = 'Old ' if docker.use_old_repo else '' %}
 
-{%- if grains['os']|lower in ('debian', 'ubuntu',) %}
+{%- if grains['os_family']|lower in ('debian',) %}
 {% set url = 'https://apt.dockerproject.org/repo ' ~ grains["os"]|lower ~ '-' ~ grains["oscodename"] ~ ' main' if docker.use_old_repo else docker.repo.url_base ~ ' ' ~ docker.repo.version ~ ' stable' %}
 
 docker-package-repository:
@@ -27,7 +27,7 @@ docker-package-repository:
     - require:
       - pkg: docker-package-dependencies
 
-{%- elif grains['os']|lower in ('centos', 'fedora') %}
+{%- elif grains['os_family']|lower in ('redhat',) %}
 {% set url = 'https://yum.dockerproject.org/repo/main/centos/$releasever/' if docker.use_old_repo else docker.repo.url_base %}
 
 docker-package-repository:


### PR DESCRIPTION
I had troubles to use the formula on Raspbian, which has os_family Debian. The repo was not created. I've changed the lookup to os_family to also include possible other OS's. Should this be okay?