### PR TITLE
Install /usr/local/bin/pip or /usr/bin/pip

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -2,6 +2,7 @@
 
 docker:
   process_signature: '/usr/bin/docker'
+  install_pypi_pip: False
   install_docker_py: False
   refresh_repo: True
   configfile: /etc/default/docker

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -63,6 +63,10 @@ docker-service:
 docker-py requirements:
   pkg.installed:
     - name: {{ docker.pip.pkgname }}
+    - onlyif: {{ not docker.install_pypi_pip }}
+  pip.installed:
+    - name: pip
+    - onlyif: {{ docker.install_pypi_pip }}
 
 docker-py:
   pip.installed:

--- a/pillar.example
+++ b/pillar.example
@@ -55,9 +55,12 @@ docker-pkg:
 
 # Docker compose supported attributes
 docker:
+  #install_pypi_pip: True
+  #install_docker_py: True
   # version of docker-compose to install (defaults to latest)
   #compose_version: 1.9.0
   #configfile: /etc/default/docker
+  install_pypi_pip: True
 
   pkg:
   # Package handling


### PR DESCRIPTION
This PR allows `/usr/local/bin/pip` to be used instead of /usr/bin/pip if  both `install_docker_py` and install_pypi_pip` pillars are explicitly set to TRUE (default false). 
