### PR TITLE
Install docker modules for system python

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -22,6 +22,10 @@ docker:
     allow_updates: False
     hold: False
 
+  pkgs:
+    - python-docker
+    - docker-compose
+
   pip:
     pkgname: python-pip
     upgrade: False

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -62,7 +62,11 @@ docker-service:
 {% if docker.install_docker_py %}
 docker-py requirements:
   pkg.installed:
-    - name: {{ docker.pip.pkgname }}
+    - names:
+      - {{ docker.pip.pkgname }}
+   {%- for pkgname in docker.pkgs %}
+      - {{ pkgname }}
+   {%- endfor %}
 
 docker-py:
   pip.installed:

--- a/docker/osmap.yaml
+++ b/docker/osmap.yaml
@@ -1,5 +1,8 @@
 
 CentOS:
+  pkgs:
+    - epel-release
+    - python2-dockerpty
   pip:
     pkgname: python2-pip
 


### PR DESCRIPTION
This PR installs the OS docker python packages so modules are available to default python if needed.