### PR TITLE
DRY: consolidate pip states & ensure pip installs

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -3,12 +3,6 @@
 include:
   - docker
 
-docker-compose-pip:
-  pkg.installed:
-    - name: {{ docker.pip.pkgname }}
-    - require_in:
-      - pip: docker-compose
-
 docker-compose:
   pip.installed:
     {%- if docker.compose_version %}
@@ -19,4 +13,7 @@ docker-compose:
     {%- if docker.proxy %}
     - proxy: {{ docker.proxy }}
     {%- endif %}
-    - reload_modules: True
+    - require:
+      - pip: docker-package-dependencies
+      - pkg: docker-package-dependencies
+    - reload_modules: {{ docker.refresh_repo }}

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -22,6 +22,10 @@ docker:
     allow_updates: False
     hold: False
 
+  pkgs:
+    - python-docker
+    - docker-compose
+
   pip:
     pkgname: python-pip
     upgrade: False

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -2,11 +2,12 @@
 
 docker:
   process_signature: '/usr/bin/docker'
-  install_pypi_pip: False
+  use_pypi_pip: False
   install_docker_py: False
   refresh_repo: True
   configfile: /etc/default/docker
   config: []
+  pip: []
 
   use_upstream_repo: True
   use_old_repo: False
@@ -24,12 +25,11 @@ docker:
     hold: False
 
   pkgs:
+    - iptables
+    - ca-certificates
     - python-docker
     - docker-compose
-
-  pip:
-    pkgname: python-pip
-    upgrade: False
+    - python-pip
 
   compose_version:
 

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -62,7 +62,11 @@ docker-service:
 {% if docker.install_docker_py %}
 docker-py requirements:
   pkg.installed:
-    - name: {{ docker.pip.pkgname }}
+    - names:
+      - {{ docker.pip.pkgname }}
+   {%- for pkgname in docker.pkgs %}
+      - {{ pkgname }}
+   {%- endfor %}
 
 docker-py:
   pip.installed:

--- a/docker/osfamilymap.yaml
+++ b/docker/osfamilymap.yaml
@@ -1,4 +1,7 @@
 Debian:
+  pkgs:
+    - apt-transport-https
+    - python-apt
   repo:
     url_base: https://download.docker.com/linux/{{ grains['os'] |lower }}
     key_url: https://download.docker.com/linux/{{ grains['os'] |lower }}/gpg

--- a/docker/osmap.yaml
+++ b/docker/osmap.yaml
@@ -3,11 +3,10 @@ CentOS:
   pkgs:
     - epel-release
     - python2-dockerpty
-  pip:
-    pkgname: python2-pip
+    - python2-pip
 
 FreeBSD:
-  pip:
-    pkgname: devel/py-pip
+  pkgs:
+    - devel/py-pip
 
 # vim: ft=sls

--- a/docker/osmap.yaml
+++ b/docker/osmap.yaml
@@ -1,5 +1,8 @@
 
 CentOS:
+  pkgs:
+    - epel-release
+    - python2-dockerpty
   pip:
     pkgname: python2-pip
 

--- a/pillar.example
+++ b/pillar.example
@@ -55,7 +55,7 @@ docker-pkg:
 
 # Docker compose supported attributes
 docker:
-  #install_pypi_pip: True
+  #use_pypi_pip: True
   #install_docker_py: True
   # version of docker-compose to install (defaults to latest)
   #compose_version: 1.9.0


### PR DESCRIPTION
This PR moves duplicate python-pip/pip package states to tidyup implementation. 

The second fix was moving pip state outside the  `{% if docker.install_docker_py %}` conditional to stop  **_docker_image' virtual returned False_** errors being caused by missing pip when `init.sls` state executes by itself.  The `compose` SLS always installs python-pip so `init.sls` should do same.

