### PR TITLE
Allow use of `hold` and `allow_updates` parameters` for docker pkg.installed

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -33,8 +33,8 @@ docker-package:
       - pkgrepo: docker-package-repository
       {%- endif %}
     - refresh: {{ docker.refresh_repo }}
-    - allow_updates: {{ docker.allow_updates }}
-    - hold: {{ docker.hold }}
+    - allow_updates: {{ docker.pkg.allow_updates }}
+    - hold: {{ docker.pkg.hold }}
     - require:
       - pkg: docker-package-dependencies
       {%- if grains['os']|lower not in ('amazon', 'fedora', 'suse',) %}

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -33,6 +33,8 @@ docker-package:
       - pkgrepo: docker-package-repository
       {%- endif %}
     - refresh: {{ docker.refresh_repo }}
+    - allow_updates: {{ docker.allow_updates }}
+    - hold: {{ docker.hold }}
     - require:
       - pkg: docker-package-dependencies
       {%- if grains['os']|lower not in ('amazon', 'fedora', 'suse',) %}


### PR DESCRIPTION
Currently there are defaults set for `hold` and `allow_updates` which are used in pkg.installed. But they are never passed in. This will allow them to be used