### PR TITLE
Revert two issues introduced by #151

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -26,9 +26,6 @@ docker-package:
   pkg.installed:
     - name: {{ docker_pkg_name }}
     - version: {{ docker_pkg_version }}
-    - refresh: {{ docker.refresh_repo }}
-    - require:
-      - pkg: docker-package-dependencies
       {%- if grains['os']|lower not in ('amazon', 'fedora', 'suse',) %}
       - pkgrepo: docker-package-repository
       {%- endif %}
@@ -39,6 +36,7 @@ docker-package:
       - pkgrepo: docker-package-repository
       {%- endif %}
     - require_in:
+      - file: docker-config
 
 docker-config:
   file.managed:


### PR DESCRIPTION
This PR fixes two issues caused by PR #151.
- two `require' clauses - one is enough.
- two 'refresh' clauses - ditto
- missing 'require_in' mapping

This was noticed testing on Suse
```
 ID: docker-package-dependencies
    Function: pkg.installed
      Result: False
     Comment: An error was encountered while installing package(s): Zypper command failure: Package 'docker-package-dependencies' not found.
     Started: 07:38:51.027440
    Duration: 14981.001 ms
     Changes:   
----------
          ID: docker-package
    Function: pkg.installed
        Name: docker-ce
      Result: False
     Comment: One or more requisite failed: docker.docker-package-dependencies
     Changes:   
----------
          ID: docker-package
    Function: pip.installed
        Name: pip
      Result: False
     Comment: One or more requisite failed: docker.docker-package-dependencies
     Changes:   
```