### PR TITLE
Fixed broken link in Readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ with one another. Use `docker.compose-ng` to run `docker-compose`.
 ``docker.compose-ng``
 ---------------------
 
-The intent is to provide an interface similar to the `specification <https://docs.docker.com/compose/yml/>`_
+The intent is to provide an interface similar to the `specification <https://docs.docker.com/compose/compose-file/>`_
 provided by docker-compose. The hope is that you may provide pillar data
 similar to that which you would use to define services with docker-compose. The
 assumption is that you are already using pillar data and salt formulae to
@@ -194,7 +194,7 @@ Stop Docker daemon. Remove older docker packages (usually called 'docker' and 'd
 Development
 ===========
 
-Note that some of the internal states such as `docker.running` are references to the internal `dockerio states <https://docs.saltstack.com/en/latest/ref/states/all/salt.states.dockerio.html>`
+Note that some of the internal states such as `docker.running` are references to the internal `dockerio states <https://docs.saltstack.com/en/latest/ref/states/all/salt.states.dockerio.html>`_
 
 
 Testing


### PR DESCRIPTION
Fixed a broken link to the docker compose file specifications.
Added an underscore to the development link so it became a clickable "dockerio states" link.