### PR TITLE
Fix systemd warning on unit files

### DIFF
--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -6,7 +6,8 @@ include:
 {% for name, container in containers.items() %}
 docker-image-{{ name }}:
   cmd.run:
-    - name: docker pull {{ container.image }}
+    - name: docker pull {{ container.image }} | grep "Image is up to date" >/dev/null 2>&1 || echo "changed=yes comment='Image updated'"
+    - stateful: True
     - require:
       - service: docker-service
 

--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -19,11 +19,12 @@ docker-container-startup-config-{{ name }}:
   file.managed:
 {%- if init_system == "systemd" %}
     - name: /etc/systemd/system/docker-{{ name }}.service
+    - mode: 644
 {%- elif init_system == "upstart" %}
     - name: /etc/init/docker-{{ name }}.conf
+    - mode: 700
 {%- endif %}
     - source: salt://docker/files/service_file.jinja
-    - mode: 700
     - user: root
     - template: jinja
     - defaults:


### PR DESCRIPTION
Hi,

This fix these warning

```
 systemd: Configuration file /etc/systemd/system/docker-vpnssl-bo-gw.service is marked executable. Please remove executable permission bits. Proceeding anyway.
 systemd: Configuration file /etc/systemd/system/docker-vpnssl-bo-gw.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
```

Best regards,