### PR TITLE
fix(syntax): param 'refresh' replaces 'refresh_db'

### DIFF
--- a/docker/repo.sls
+++ b/docker/repo.sls
@@ -21,7 +21,11 @@ docker-package-repository:
     {% else %}
     - key_url: {{ docker.repo.key_url }}
     {% endif %}
+        {%- if grains['saltversioninfo'] >= [2018, 3, 0] %}
+    - refresh: True
+        {%- else %}
     - refresh_db: True
+        {%- endif %}
     - require_in:
       - pkg: docker-package
     - require:


### PR DESCRIPTION
Fix this
```
[WARNING ] /usr/lib/python3/dist-packages/salt/states/pkgrepo.py:313: 
DeprecationWarning: The 'refresh_db' argument to 'pkg.mod_repo' has 
been renamed to 'refresh'. Support for using 'refresh_db' will 
be removed in the Neon release of Salt.
```