### PR TITLE
fix(tests): fix some issues with tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,7 @@ platforms:
   - name: ubuntu-18.04
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown
+        - apt-get update && apt-get install -y locales ifupdown python3-yaml python3-jinja2
         - locale-gen en_US.UTF-8
         - update-locale LANG=en_US.UTF-8
         - mkdir -p /run/sshd
@@ -32,13 +32,13 @@ platforms:
   - name: debian-stretch
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown
+        - apt-get update && apt-get install -y locales ifupdown apt-transport-https ca-certificates python3-yaml python3-jinja2
         - locale-gen en_US.UTF-8
       run_command: /lib/systemd/systemd
   - name: debian-jessie
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown
+        - apt-get update && apt-get install -y locales ifupdown apt-transport-https ca-certificates python3-yaml python3-jinja2
         - locale-gen en_US.UTF-8
       run_command: /lib/systemd/systemd
 #   - name: centos-7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,7 @@ platforms:
   - name: ubuntu-18.04
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown python3-yaml python3-jinja2
+        - apt-get update && apt-get install -y locales ifupdown apt-transport-https
         - locale-gen en_US.UTF-8
         - update-locale LANG=en_US.UTF-8
         - mkdir -p /run/sshd
@@ -32,13 +32,13 @@ platforms:
   - name: debian-stretch
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown apt-transport-https ca-certificates python3-yaml python3-jinja2
+        - apt-get update && apt-get install -y locales ifupdown apt-transport-https
         - locale-gen en_US.UTF-8
       run_command: /lib/systemd/systemd
   - name: debian-jessie
     driver_config:
       provision_command:
-        - apt-get update && apt-get install -y locales ifupdown apt-transport-https ca-certificates python3-yaml python3-jinja2
+        - apt-get update && apt-get install -y locales ifupdown apt-transport-https
         - locale-gen en_US.UTF-8
       run_command: /lib/systemd/systemd
 #   - name: centos-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ sudo: required
 
 
 language: python
+python:
+  - "3.6"
+  # PyPy versions
+  - "pypy3.5"
 
 services:
   - docker
 
+dist: bionic
+
 before_install:
   - bundle install
-
+  - sudo apt-get update
+  - sudo apt-get install python3
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: required
 language: python
 python:
   - "3.6"
-  # PyPy versions
-  - "pypy3.5"
 
 services:
   - docker

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
-gem "test-kitchen"
-gem "kitchen-docker"
-gem "kitchen-salt"
+gem 'test-kitchen', '>= 2.2.5'
+gem 'kitchen-docker', '>= 2.9'
+gem 'kitchen-salt', '>= 0.6.0'
+gem 'kitchen-inspec', '>= 1.1'
+gem 'net-ssh', '>= 5.2.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-py==1.4.31
-pytest==3.0.3
-six==1.10.0
-testinfra==1.4.2
+py==1.8.0
+pytest==5.0.0
+six==1.12.0
+testinfra==3.0.5
+pyyaml==3.13
+jinja2==2.10.1

--- a/test/integration/default/testinfra/test_docker.py
+++ b/test/integration/default/testinfra/test_docker.py
@@ -4,7 +4,7 @@ import testinfra
 def test_package_is_installed(Package):
     docker = Package('docker-ce')
     assert docker.is_installed
-    assert docker.version.startswith('18.')
+    assert docker.version.startswith('5.18.')
 
 def test_service_is_running_and_enabled(Service):
     docker = Service('docker')


### PR DESCRIPTION
Fix unittest for `docker-ce` and kitchen platform for debian.

**Ubuntu**
```
    def test_package_is_installed(Package):
        docker = Package('docker-ce')
        assert docker.is_installed
>       assert docker.version.startswith('18.')
E       assert False
E        +  where False = <built-in method startswith of str object at 0x7fc47379ab70>('18.')
E        +    where <built-in method startswith of str object at 0x7fc47379ab70> = '5:18.09.7~3-0~ubuntu-bionic'.startswith
E        +      where '5:18.09.7~3-0~ubuntu-bionic' = <package docker-ce>.version
```

**Debian**
```
                 ID: docker-package-dependencies
           Function: pkg.installed
             Result: False
            Comment: An error was encountered while installing package(s): E: The method driver /usr/lib/apt/methods/https could not be found.
              E: Failed to fetch https://repo.saltstack.com/apt/debian/9/amd64/latest/dists/stretch/InRelease  
              E: Some index files failed to download. They have been ignored, or old ones used instead.
```