### PR TITLE
Make it easier when using salt-ssh

### DIFF
--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -23,11 +23,11 @@
     },
 }, merge=salt['pillar.get']('registry:lookup:amazon')) %}
 
-# Begin migration to new style map.jinja
-{% import_yaml "docker/defaults.yaml" as defaults %}
-{% import_yaml 'docker/osfamilymap.yaml' as osfamilymap %}
-{% import_yaml "docker/codenamemap.yaml" as codemap %}
-{% import_yaml "docker/osmap.yaml" as osmap %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{% import_yaml tplroot ~ "/defaults.yaml" or {} as defaults %}
+{% import_yaml tplroot ~ "/osfamilymap.yaml" or {} as osfamilymap %}
+{% import_yaml tplroot ~ "/codenamemap.yaml" or {} as codemap %}
+{% import_yaml tplroot ~ "/osmap.yaml" or {} as osmap %}
 
 {% set pkg = salt['pillar.get']('docker-pkg:lookup', default={}, merge=True) %}
 {% do defaults.docker.update(pkg) %}

--- a/docker/repo.sls
+++ b/docker/repo.sls
@@ -8,7 +8,8 @@
 {% set humanname_old = 'Old ' if docker.use_old_repo else '' %}
 
 {%- if grains['os_family']|lower in ('debian',) %}
-{% set url = 'https://apt.dockerproject.org/repo ' ~ grains["os"]|lower ~ '-' ~ grains["oscodename"] ~ ' main' if docker.use_old_repo else docker.repo.url_base ~ ' ' ~ docker.repo.version ~ ' stable' %}
+{% set url = '[arch=' ~ grains["osarch"] ~ '] https://apt.dockerproject.org/repo ' ~ grains["os"]|lower ~ '-' ~ grains["oscodename"] ~ ' main' if docker.use_old_repo else '[arch=' ~ grains["osarch"] ~ '] ' ~ docker.repo.url_base ~ ' ' ~ docker.repo.version ~ ' stable' %}
+
 
 docker-package-repository:
   pkgrepo.{{ repo_state }}:


### PR DESCRIPTION
Using the tplroot method (borrowed from the ufw-formula) prevents having to set --extra-filerefs when using the formula with salt-ssh.

I've only tested it on my own salt deployment which worked without a hitch. 
