### PR TITLE
Portable imports and fix for apt sources.list regarding osarch.

### DIFF
--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -1,5 +1,7 @@
-{%- from "docker/map.jinja" import docker with context %}
-{%- from "docker/map.jinja" import compose with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
+{%- from tplroot ~ "/map.jinja" import compose with context %}
 
 include:
   - docker.compose

--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import docker with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 include:
   - docker

--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import containers with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import containers with context %}
 
 include:
   - docker

--- a/docker/files/config
+++ b/docker/files/config
@@ -1,6 +1,3 @@
-{% from "docker/map.jinja" import docker with context %}
-
-
 # Docker Upstart and SysVinit configuration file
 
 #
@@ -22,6 +19,6 @@
 # This is also a handy place to tweak where Docker's temporary files go.
 #export TMPDIR="/mnt/bigdrive/docker-tmp"
 
-{% for line in docker.get("config", []) %}
+{% for line in config %}
 {{ line }}
 {% endfor %}

--- a/docker/files/upstart.conf.deprecated.registry
+++ b/docker/files/upstart.conf.deprecated.registry
@@ -1,5 +1,7 @@
-{% from "docker/map.jinja" import registry with context %}
-{% from "docker/map.jinja" import amazon with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import registry with context %}
+{%- from tplroot ~ "/map.jinja" import amazon with context %}
 
 description "{{ registry.description }}"
 start on runlevel [2345]

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import docker with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 {%- set docker_pkg_name = docker.pkg.old_name if docker.use_old_repo else docker.pkg.name %}
 {%- set docker_pkg_version = docker.version | default(docker.pkg.version) %}
@@ -61,6 +63,8 @@ docker-config:
       - pkg: docker-package
     - watch_in:
       - service: docker-service
+    - context:
+        config: {{ docker.config }}
   {%- endif %}
 
   {% if docker.daemon_config %}

--- a/docker/kernel.sls
+++ b/docker/kernel.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import docker with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 {%- if docker.kernel is defined and grains['os_family']|lower == 'debian' %}
 pkgrepo-dependencies:

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -23,11 +23,14 @@
     },
 }, merge=salt['pillar.get']('registry:lookup:amazon')) %}
 
-# Begin migration to new style map.jinja
-{% import_yaml "docker/defaults.yaml" as defaults %}
-{% import_yaml 'docker/osfamilymap.yaml' as osfamilymap %}
-{% import_yaml "docker/codenamemap.yaml" as codemap %}
-{% import_yaml "docker/osmap.yaml" as osmap %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+
+{# Begin migration to new style map.jinja using tplroot for portability #}
+{% import_yaml tplroot ~ "/defaults.yaml" or {} as defaults %}
+{% import_yaml tplroot ~ "/osfamilymap.yaml" or {} as osfamilymap %}
+{% import_yaml tplroot ~ "/codenamemap.yaml" or {} as codemap %}
+{% import_yaml tplroot ~ "/osmap.yaml" or {} as osmap %}
 
 {% set pkg = salt['pillar.get']('docker-pkg:lookup', default={}, merge=True) %}
 {% do defaults.docker.update(pkg) %}

--- a/docker/registry.sls
+++ b/docker/registry.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import registry with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 file-registry-upstart-conf:
   file.managed:

--- a/docker/remove.sls
+++ b/docker/remove.sls
@@ -1,4 +1,6 @@
-{% from "docker/map.jinja" import docker with context %}
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 docker-packages-cleaned-service-dead:
   service.dead:

--- a/docker/repo.sls
+++ b/docker/repo.sls
@@ -1,4 +1,7 @@
-{% from "docker/map.jinja" import docker with context %}
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import docker with context %}
 
 {% set repo_state = 'absent' %}
 {% if docker.use_upstream_repo or docker.use_old_repo %}
@@ -13,7 +16,7 @@
 docker-package-repository:
   pkgrepo.{{ repo_state }}:
     - humanname: {{ grains["os"] }} {{ grains["oscodename"]|capitalize }} {{ humanname_old }}Docker Package Repository
-    - name: deb {{ url }}
+    - name: deb [arch={{ grains["osarch"] }}] {{ url }}
     - file: {{ docker.repo.file }}
     {% if docker.use_old_repo %}
     - keyserver: keyserver.ubuntu.com


### PR DESCRIPTION
This time a version that works. Yesterday was too much of a rush job, apologies for that.

I've tested it several times with salt ssh on a clean machine, removed the thin cache this time ;)

Did not test:
- using it normally (not salt-ssh)
- using a target machine other then osarch amd64.

Setup:

top.sls
```
base:
   '*':
      - docker 
```

cmd line:
```
salt-ssh --roster=scan 10.10.0.10 state.apply
``` 

Result -> succeeded

Commit msg:

Use tpldir to make imports work from e.g. salt-ssh without having to resort to --extra-filerefs=salt://docker/map.jinja,... on the cmd line.

Also added the os architecture to the apt sources.list line: deb [arch=<osarch>] http://... 