### PR TITLE
fix(sls): fix unnecessary sls rendering error

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -34,8 +34,6 @@ docker-package:
     - allow_updates: {{ docker.pkg.allow_updates }}
     - hold: {{ docker.pkg.hold }}
         {%- endif %}
-    - require_in:
-      - file: docker-config
         {%- if grains.os_family in ('Suse',) %}   ##workaround https://github.com/saltstack-formulas/docker-formula/issues/198
   cmd.run:
     - name: /usr/bin/pip install {{ '--upgrade' if docker.pip.upgrade else '' }} pip


### PR DESCRIPTION
This PR fixes a rendering error on MacOS and removes the duplicated `require..` clause.

```
    Data failed to compile:
----------
    Cannot extend ID 'docker-config' in 'base:docker'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'docker-config' is available
in environment 'base' and to SLS 'docker'
```