### PR TITLE
feat(linux): archlinux support & improvements

### DIFF
--- a/docker/compose.sls
+++ b/docker/compose.sls
@@ -11,7 +11,7 @@ docker-compose:
     - name: /usr/bin/pip install docker-compose
       {%- else %}
   pip.installed:
-         {%- if docker.compose_version %}
+         {%- if 'compose_version' in docker and docker.compose_version %}
     - name: docker-compose == {{ docker.compose_version }}
          {%- else %}
     - name: docker-compose

--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -18,7 +18,6 @@ docker:
   pkgs:
     - iptables
     - ca-certificates
-    - python3-docker
 
   pkg:
     name: docker-ce

--- a/docker/osfamilymap.yaml
+++ b/docker/osfamilymap.yaml
@@ -14,11 +14,28 @@
   {% set macos_user = salt['cmd.run']("stat -f '%Su' /dev/console") %}
 {%- endif %}
 
+Arch:
+  python_package:
+  pkgs:
+    - python-docker
+    - python-pip
+    - python2-pip     ##see https://github.com/saltstack/salt/issues/48632
+  pkg:
+    name: docker
+    # workaround https://github.com/saltstack-formulas/docker-formula/issues/219
+    allow_updates: False
+    hold: False
+    use_upstream_app: False
+  pip:
+    install_pypi_pip: False
+    upgrade: False
+
 Debian:
   pkgs:
     - apt-transport-https
     - python3-apt
     - python3-pip
+    - python3-docker
   repo:
     url_base: https://download.docker.com/linux/{{ grains['os'] |lower }}
     key_url: https://download.docker.com/linux/{{ grains['os'] |lower }}/gpg
@@ -28,8 +45,9 @@ Debian:
 RedHat:
   pkgs:
     - python3-pip
+    - python3-docker
   repo:
-    url_base: https://download.docker.com/linux/{{ grains['os'] |lower }}/{{ grains['osmajorrelease'] }}/$basearch/stable/
+    url_base: https://download.docker.com/linux/{{ grains['os'] |lower }}/{{ '' if not 'osmajorrelease' in grains else grains['osmajorrelease'] }}/$basearch/stable/
     key_url: https://download.docker.com/linux/{{ grains['os'] |lower }}/gpg
     version: {{ grains['oscodename']|lower if 'oscodename' in grains else '' }}
     file: /etc/yum.repos.d/docker-ce.repo
@@ -39,11 +57,15 @@ Suse:
     name: docker
   pkgs:
     - python3-pip
+    - python3-docker
 
 MacOS:
   rootuser: {{ macos_user | d('') }}
+  pkgs:
+    - python3-docker
   pkg:
     name: docker              #homebrew
+    # workaround https://github.com/saltstack-formulas/docker-formula/issues/219
     allow_updates: False
     hold: False
     use_upstream_app: True    #docker desktop for mac


### PR DESCRIPTION
This PR introduces **Archlinux support**, resolves #228 and works around #219.

Note:
During Arch verification I observed https://github.com/saltstack-formulas/docker-formula/issues/203 again.
```
Jul 30 20:52:40 archlinux.vagrant.vm dockerd[18327]: failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER>
Jul 30 20:52:40 archlinux.vagrant.vm dockerd[18327]: Perhaps iptables or your kernel needs to be upgraded.
Jul 30 20:52:40 archlinux.vagrant.vm dockerd[18327]:  (exit status 3)
```
So I added `test.show_notification` state to communicate #203 solution.