### PR TITLE
Optionally support removing container before trying to start it 

### DIFF
--- a/docker/files/service_file.jinja
+++ b/docker/files/service_file.jinja
@@ -8,6 +8,7 @@
 {%- set stopoptions = stopoptions|join(' ') %}
 {%- set args = args|join(' ') %}
 
+{%- set docker_prestart_remove_command = "rm -f %s"|format(name) %}
 {%- set docker_start_command = "run %s --name=%s %s %s %s"|format(runoptions, name, container.image, cmd, args)  %}
 {%- set docker_stop_command = "stop %s %s"|format(stopoptions, name) %}
 {%- set docker_poststop_command = "rm -f %s"|format(name) %}

--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -5,6 +5,7 @@ After=docker.service
 
 {%- set remove_on_stop = container.get("remove_on_stop", False) %}
 {%- set pull_before_start = container.get("pull_before_start") or False %}
+{%- set remove_before_start = container.get("remove_before_start") or False %}
 
 [Service]
 Restart=always
@@ -12,6 +13,9 @@ Restart=always
 ExecStartPre=/usr/bin/docker pull {{ container.image }}
 {%- endif %}
 
+{%- if remove_before_start %}
+ExecStartPre=-/usr/bin/docker {{ docker_prestart_remove_command }}
+{%- endif %}
 ExecStart=/usr/bin/docker {{ docker_start_command }}
 ExecStop=/usr/bin/docker {{ docker_stop_command }}
 {%- if remove_on_stop %}

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -11,10 +11,17 @@ respawn
 {%- set cmd = container.get("cmd", "") %}
 
 {%- set pull_before_start = container.get("pull_before_start") or False %}
+{%- set remove_before_start = container.get("remove_before_start") or False %}
 
 {%- if pull_before_start %}
 pre-start script
   /usr/bin/docker pull {{ container.image }}
+end script
+{%- endif %}
+
+{%- if remove_before_start %}
+pre-start script
+  /usr/bin/docker rm -f {{ name }}
 end script
 {%- endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,8 @@ docker-containers:
       # Pull image on service restart
       # (useful if you override the same tag.  example: latest)
       pull_before_start: true
+      # Remove container on service start
+      remove_before_start: false
       # Do not force container removal on stop (unless true)
       remove_on_stop: false
       runoptions:
@@ -38,6 +40,8 @@ docker-containers:
       # Pull image on service restart
       # (useful if you override the same tag. example: latest)
       pull_before_start: true
+      # Remove container on service start
+      remove_before_start: false
       # Do not force container removal on stop (unless true)
       remove_on_stop: false
       runoptions:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This should avoid this problem when trying to start the service (and the container was created but not running). For example:

```
/usr/bin/docker: Error response from daemon: Conflict. The container name "/ecs-agent" is already in use by container "22cb0febefdfe96ba2558dd33329fb428c7ed45a2145361d25e8faf331b18428". You have to remove (or rename) that container to be able to reuse that name.
```

I hit the problem with the AWS ecs-agent and in their [ECS developer guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-dg.pdf) (on page 212), you can see that they have their systemd unit file using an `ExecStartPre` to remove the container before trying to start it.

This is useful if say the container gets created from a failed run. If you try to run it again, it will continue to fail because the container was created with the same name.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

See the `pillar.example`.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


