### PR TITLE
fix(service): change default service name

### DIFF
--- a/docker/defaults.yaml
+++ b/docker/defaults.yaml
@@ -39,7 +39,7 @@ docker:
 
       name: docker-ce
       service:
-        name: dockerd
+        name: docker
         env: ''
       suffix: tgz
       commands:

--- a/docker/files/default/systemd.ini.jinja
+++ b/docker/files/default/systemd.ini.jinja
@@ -5,7 +5,7 @@
 Description={{ desc }}
 Wants=network-online.target
 After=
-Documentation=https://github.com/saltstack-formulas/prometheus-formula
+Documentation=https://docs.docker.com
 
 [Service]
 User={{ user }}

--- a/docker/software/archive/install.sls
+++ b/docker/software/archive/install.sls
@@ -94,7 +94,7 @@
         workdir: {{ d.dir.lib }}
         env: {{ d.pkg.docker.service.env }}
         stop: ''
-        start: {{ d.pkg.docker.path }}/{{ d.pkg.docker.service.name }}
+        start: {{ d.pkg.docker.path }}/dockerd
   cmd.run:
     - name: systemctl daemon-reload
     - require:

--- a/docker/software/service/running.sls
+++ b/docker/software/service/running.sls
@@ -44,12 +44,13 @@ include:
         {%- endif %}
     - enable: True
         {%- if grains.kernel|lower == 'linux' %}
-    - onlyif: systemctl list-unit-files | grep {{ d.pkg.docker.service.name }} >/dev/null 2>&1
 
 {{ formula }}-software-service-running-docker-fail-notify:
-  test.show_notification:
-    - text: |
-        * Rebooting your host is recommended!
+  test.fail_without_changes:
+    - comment: |
+        Formula is trying to start '{{ d.pkg.docker.service.name }}' service
+        but failed, is it a correct name for Docker service in your OS?
+
         In certain circumstances the docker service will not start.
         Your kernel is missing some modules, or not in ideal state.
         See https://github.com/moby/moby/blob/master/contrib/check-config.sh

--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,7 @@ docker:
   pkg:
     docker:
       service:
+        name: docker
         env: HTTP_PROXY=http://YOUR_PROXY_IP_ADDRESS:PROXY_PORT
       environ:
         # yamllint disable-line rule:line-length

--- a/test/integration/archive/controls/service.rb
+++ b/test/integration/archive/controls/service.rb
@@ -6,6 +6,6 @@ control 'Docker service' do
   describe service('docker') do
     it { should be_installed }
     it { should be_enabled }
-    # it { should be_running }
+    it { should be_running } unless %w[fedora suse].include? platform[:family]
   end
 end

--- a/test/integration/archive/controls/service.rb
+++ b/test/integration/archive/controls/service.rb
@@ -3,7 +3,7 @@
 control 'Docker service' do
   title 'should be running and enabled'
 
-  describe service('dockerd') do
+  describe service('docker') do
     it { should be_installed }
     it { should be_enabled }
     # it { should be_running }

--- a/test/integration/package/controls/service.rb
+++ b/test/integration/package/controls/service.rb
@@ -3,8 +3,9 @@
 control 'Docker service' do
   title 'should be running and enabled'
 
-  # describe service(name) do
-  #   it { should be_enabled }
-  #   it { should be_running }
-  # end
+  describe service('docker') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
 end


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes.

BREAKING CHANGE: due changes in default service name, on systems where 'archive' installation method is used, duplicate service will be created. This can be avoided by updating pillar with 'docker:pkg:docker:service:name: dockerd'. Due fact that 'archive' method is default this change may affect a large number of users

### Related issues and/or pull requests

Closes #273 

### Describe the changes you're proposing

Docker daemon service name in official Docker packages is 'docker' but formula uses 'dockerd'. Due to these differences docker service won't start after installation if `package` installation method is selected - `docker:pkg:docker:use_upstream: repo` .

Fix documentation link in systemd service

`docker/software/archive/install.sls`
Docker daemon binary in official Docker archive distribution is always 'dockerd' no reason to substitute service name

`defaults.yaml`
'null' from yaml is rendering as 'None' by Jinja therefore, systemd displays a warning in the log, replace with empty string to prevent this issue


### Pillar / config required to test the proposed changes

```yaml
docker:
  pkg:
    docker:
      use_upstream: repo
```


### Debug log showing how the proposed changes work
```
2021-03-10 17:24:59,564 [salt.template    :122 ][DEBUG   ][2654] Rendered data from file: /var/cache/salt/minion/files/base/docker/software/service/running.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - docker.software.package.install
  - docker.software.config.file

docker-software-service-running-unmasked:
  service.unmasked:
    - name: docker
    - onlyif: systemctl list-unit-files | grep docker >/dev/null 2>&1
    - require_in:
      - service: docker-software-service-running-docker

docker-software-service-running-docker:
  service.running:
    - name: docker
    - enable: True

docker-software-service-running-docker-fail-notify:
  test.fail_without_changes:
    - comment: |
        Formula is trying to start 'docker' service
        but failed, is it a correct name for Docker service in your OS?

        In certain circumstances the docker service will not start.
        Your kernel is missing some modules, or not in ideal state.
        See https://github.com/moby/moby/blob/master/contrib/check-config.sh
        * Rebooting your host is recommended!
    - onfail:
      - service: docker-software-service-running-docker
  service.enabled:
    - onlyif: True
    - name: docker
    - onfail:
      - service: docker-software-service-running-docker
```

### Documentation checklist

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context

Better merge this after #276
